### PR TITLE
Reduce the frontend Docker build context

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.tsbuildinfo
+.DS_Store


### PR DESCRIPTION
Adds a frontend-specific `.dockerignore` so local dependencies and generated build output are never sent to the Docker daemon.

- no runtime behavior changes
- local test/lint/build already pass
- privacy scan remains clean