### PR TITLE
ci: remove deprecated Node 20 action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with: { python-version: "3.12", cache: pip }
       - run: python -m pip install -e 'backend[dev]'
       - run: ruff check backend scripts
@@ -31,8 +31,8 @@ jobs:
     timeout-minutes: 10
     defaults: { run: { working-directory: frontend } }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with: { node-version: 22, cache: npm, cache-dependency-path: frontend/package-lock.json }
       - run: npm ci
       - run: npm run lint
@@ -44,8 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with: { python-version: "3.12" }
       - run: python3 scripts/check_docs.py
 
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Start hardened Compose stack
         run: |
           cp .env.example .env


### PR DESCRIPTION
## Summary

Updates the official GitHub-maintained actions used by CI to their current v7 major releases:

- `actions/checkout@v7`
- `actions/setup-python@v7`
- `actions/setup-node@v7`

The previous actions emitted Node.js 20 deprecation annotations on every job. Current v7 releases use the supported action runtime on GitHub-hosted runners.

## Verification

- workflow YAML parsed successfully
- `git diff --check` passed
- this PR's complete CI run verifies backend, frontend, documentation, and containers on the upgraded actions

## Impact

No application runtime or API changes. Official first-party actions only; permissions remain `contents: read`.
