### PR TITLE
community: route learner conversations to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Course and setup Q&A / 课程与环境提问
+    url: https://github.com/jzjzzzzzzz/agent-me/discussions/categories/q-a
+    about: Ask for help with lessons, setup, architecture, or design without opening a bug report.
+  - name: Show your project / 展示学习成果
+    url: https://github.com/jzjzzzzzzz/agent-me/discussions/categories/show-and-tell
+    about: Share a fork, completed lab, evaluation result, or capstone with the community.
   - name: Security vulnerability
     url: https://github.com/jzjzzzzzzz/agent-me/security/advisories/new
     about: Report vulnerabilities privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/course.yml
+++ b/.github/ISSUE_TEMPLATE/course.yml
@@ -3,6 +3,7 @@ description: Report a confusing lesson, broken command, or missing explanation
 title: "[Course]: "
 labels:
   - documentation
+  - course
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

- send setup, lesson, and design questions from the issue chooser to GitHub Discussions Q&A
- send completed labs and capstones to Show and tell
- retain private security reporting
- apply the existing `course` label to course feedback issues

## Verification

- parsed every issue-form YAML file
- `python3 scripts/check_docs.py`
