### PR TITLE
docs: add Windows PowerShell setup commands

### DIFF
--- a/course/00-course-setup/README.md
+++ b/course/00-course-setup/README.md
@@ -114,6 +114,74 @@ make docs
 make evaluate
 ```
 
+##### Windows PowerShell
+
+Make is not included with Windows by default. From the repository root, use the equivalent native PowerShell commands instead:
+
+```powershell
+python --version
+node --version
+npm --version
+git --version
+
+if (!(Test-Path .env)) { Copy-Item .env.example .env }
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -e "backend[dev]"
+
+Set-Location frontend
+npm ci
+Set-Location ..
+```
+
+Run the same four quality gates without requiring Make:
+
+```powershell
+# Lint and type checking
+.\.venv\Scripts\ruff.exe check backend scripts
+.\.venv\Scripts\ruff.exe format --check backend scripts
+Set-Location frontend
+npm run lint
+npm run typecheck
+Set-Location ..
+
+# Tests
+.\.venv\Scripts\pytest.exe backend\tests
+Set-Location frontend
+npm test
+Set-Location ..
+
+# Documentation
+.\.venv\Scripts\python.exe scripts\check_docs.py
+
+# Deterministic evaluation
+.\.venv\Scripts\python.exe scripts\evaluate_collaboration.py
+```
+
+To run the application locally, start the backend and frontend in separate PowerShell terminals.
+
+Backend, from the repository root:
+
+```powershell
+.\.venv\Scripts\uvicorn.exe app.main:app --app-dir backend --reload
+```
+
+Frontend, from the repository root:
+
+```powershell
+Set-Location frontend
+npm run dev
+```
+
+Verify the backend from another PowerShell terminal:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/health
+Invoke-RestMethod http://127.0.0.1:8000/ready
+```
+
+The web application is then available at http://localhost:5173/.
+
 Expected final line:
 
 ```text


### PR DESCRIPTION
## Summary

Adds verified Windows PowerShell equivalents to the Lesson 00 local-toolchain setup so Windows learners do not need Make or have to translate Bash-specific commands themselves.

This adds PowerShell instructions for:

* virtual environment creation and activation
* backend and frontend dependency installation
* lint and type checking
* backend and frontend tests
* documentation validation
* deterministic collaboration evaluation
* backend and frontend startup
* `/health` and `/ready` verification

The existing Bash/macOS/Linux instructions are unchanged.

## Environment tested

* Windows: Windows 11 Home Single Language
* PowerShell: 5.1.22621.6133
* Python: 3.14.4
* Node.js: v24.18.0
* npm: 11.16.0
* Git: 2.54.0.windows.1
* Docker: unavailable / not installed

Docker-based validation was not run because Docker was not installed on the test environment.

## Validation

Native PowerShell equivalents were run successfully.

### Python quality checks

```powershell
.\.venv\Scripts\ruff.exe check backend scripts
.\.venv\Scripts\ruff.exe format --check backend scripts
.\.venv\Scripts\pytest.exe backend\tests
```

Results:

* Ruff: all checks passed
* Ruff format: 14 files already formatted
* Pytest: 26 passed, 1 skipped

### Frontend quality checks

```powershell
npm run lint
npm run typecheck
npm test
```

Results:

* ESLint passed
* TypeScript typecheck passed
* Vitest: 20 tests passed across 3 test files

### Documentation

```powershell
.\.venv\Scripts\python.exe scripts\check_docs.py
```

Result:

```text
Documentation check passed (45 Markdown files, 16 maintained lesson pages).
```

### Collaboration evaluation

```powershell
.\.venv\Scripts\python.exe scripts\evaluate_collaboration.py
```

Result:

```text
COLLABORATION_EVAL 3/3 passed
```

### Local runtime

Backend successfully started with:

```powershell
.\.venv\Scripts\uvicorn.exe app.main:app --app-dir backend --reload
```

Verified:

* `/health` → `healthy`
* `/ready` → `ready`
* application running in extractive mode with the example knowledge document

Frontend successfully started with:

```powershell
Set-Location frontend
npm run dev
```

Vite served the application successfully at `http://localhost:5173/`.

Closes #24
