### PR TITLE
docs: validate repository-relative Markdown heading anchors

### DIFF
--- a/backend/tests/test_check_docs.py
+++ b/backend/tests/test_check_docs.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+from scripts import check_docs
+
+
+def test_heading_anchors_follow_github_slug_rules() -> None:
+    text = (
+        "# API: v2.0 — What's New?\n"
+        "## Привет non-latin 你好\n"
+        "## This'll be a _Helpful_ Section\n"
+        "## heading with an _ underscore\n"
+        "## I ♥ unicode\n"
+        "## 😄 emoji\n"
+        "## Trimmed heading   \n"
+        "## Repeat\n"
+        "## Repeat\n"
+        "## Repeat\n"
+        "## Echo\n"
+        "## Echo\n"
+        "## Echo 1\n"
+        "## Echo-1\n"
+        "## Echo\n"
+        "Setext heading\n"
+        "---------------\n"
+        "```markdown\n"
+        "# Not a heading\n"
+        "```\n"
+    )
+
+    assert check_docs.heading_anchors(text) == {
+        "api-v20--whats-new",
+        "привет-non-latin-你好",
+        "thisll-be-a-helpful-section",
+        "heading-with-an-_-underscore",
+        "i--unicode",
+        "-emoji",
+        "trimmed-heading",
+        "repeat",
+        "repeat-1",
+        "repeat-2",
+        "echo",
+        "echo-1",
+        "echo-1-1",
+        "echo-1-2",
+        "echo-2",
+        "setext-heading",
+    }
+
+
+def test_valid_same_file_cross_file_and_percent_encoded_fragments_pass(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "source.md"
+    target = tmp_path / "guide.md"
+    source.write_text(
+        "# Local heading\n\n"
+        "[same file](#local-heading)\n"
+        "[cross file](guide.md#api-v20--whats-new)\n"
+        "[encoded Unicode](guide.md#%E4%BD%A0%E5%A5%BD-%E4%B8%96%E7%95%8C)\n"
+        "[duplicate](guide.md#repeat-1)\n"
+        "[external](https://example.com/guide.md#missing)\n"
+        "[image](diagram.png#missing)\n",
+        encoding="utf-8",
+    )
+    target.write_text(
+        "# API: v2.0 — What's New?\n\n## 你好 世界\n\n## Repeat\n\n## Repeat\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "diagram.png").write_bytes(b"image")
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+
+    assert check_docs.validate_file(source) == []
+
+
+def test_missing_fragments_name_source_destination_and_fragment(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "source.md"
+    target = tmp_path / "guide.md"
+    source.write_text(
+        "# Present\n\n[missing same](#missing-same)\n[missing cross](guide.md#missing-cross)\n",
+        encoding="utf-8",
+    )
+    target.write_text("# Present\n", encoding="utf-8")
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+
+    assert check_docs.validate_file(source) == [
+        "source.md: missing Markdown anchor in source.md: #missing-same",
+        "source.md: missing Markdown anchor in guide.md: #missing-cross",
+    ]
+
+
+def test_existing_file_owner_traversal_and_merge_marker_checks_remain(
+    tmp_path: Path, monkeypatch
+) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    source = docs / "source.md"
+    source.write_text(
+        "<<<<<<< ours\n"
+        "[missing](missing.md)\n"
+        "[outside](../../outside.md)\n"
+        "[owner](https://github.com/not-the-owner/agent-me)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+    source_name = str(Path("docs") / "source.md")
+
+    assert check_docs.validate_file(source) == [
+        f"{source_name}: unresolved merge marker <<<<<<<",
+        f"{source_name}: missing local link: missing.md",
+        f"{source_name}: link leaves repository: ../../outside.md",
+        f"{source_name}: unexpected GitHub owner in https://github.com/not-the-owner/agent-me",
+    ]

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import html
 import re
 import sys
+import unicodedata
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
@@ -43,6 +45,28 @@ CHINESE_SECTIONS = (
     "## 延伸阅读",
 )
 MERGE_MARKERS = ("<<<<<<<", "=======", ">>>>>>>")
+REMOVED_SLUG_CATEGORIES = {
+    "Cc",
+    "Cf",
+    "Cn",
+    "Co",
+    "No",
+    "Pd",
+    "Pe",
+    "Pf",
+    "Pi",
+    "Po",
+    "Ps",
+}
+ATX_HEADING = re.compile(r"^ {0,3}#{1,6}(?:[ \t]+(.*)|[ \t]*)$")
+SETEXT_HEADING = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
+FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+INLINE_LINK = re.compile(r"!?\[([^\]]*)\]\([^)]*\)")
+REFERENCE_LINK = re.compile(r"!?\[([^\]]*)\]\[[^\]]*\]")
+CODE_SPAN = re.compile(r"(`+)(.*?)\1")
+INLINE_MARKUP = re.compile(r"(?<![\w\\])([*_~]{1,3})(?=\S)(.+?)(?<=\S)\1(?!\w)")
+HTML_TAG = re.compile(r"</?[^>]+>")
+ESCAPED_MARKUP = re.compile(r"\\([\\`*{}\[\]()#+\-.!_>~|])")
 
 
 def markdown_files() -> list[Path]:
@@ -55,10 +79,102 @@ def markdown_files() -> list[Path]:
 
 
 def destination_path(destination: str) -> str:
+    return destination_parts(destination)[0]
+
+
+def destination_parts(destination: str) -> tuple[str, str]:
     value = destination.strip()
     if value.startswith("<") and value.endswith(">"):
         value = value[1:-1]
-    return value.split(maxsplit=1)[0].split("#", 1)[0]
+    value = value.split(maxsplit=1)[0]
+    path, separator, fragment = value.partition("#")
+    return path, fragment if separator else ""
+
+
+def heading_text(value: str) -> str:
+    value = INLINE_LINK.sub(r"\1", value)
+    value = REFERENCE_LINK.sub(r"\1", value)
+    value = CODE_SPAN.sub(r"\2", value)
+    value = HTML_TAG.sub("", value)
+    previous = None
+    while value != previous:
+        previous = value
+        value = INLINE_MARKUP.sub(r"\2", value)
+    return html.unescape(ESCAPED_MARKUP.sub(r"\1", value))
+
+
+def github_slug(value: str) -> str:
+    result: list[str] = []
+    for character in heading_text(value).lower():
+        category = unicodedata.category(character)
+        if character == " ":
+            result.append("-")
+        elif character == "-" or character.isalpha():
+            result.append(character)
+        elif category in REMOVED_SLUG_CATEGORIES or category.startswith(("S", "Z")):
+            continue
+        else:
+            result.append(character)
+    return "".join(result)
+
+
+def markdown_headings(text: str) -> list[str]:
+    lines = text.splitlines()
+    headings: list[str] = []
+    outside_fence = [True] * len(lines)
+    fence_character = ""
+    fence_length = 0
+
+    for index, line in enumerate(lines):
+        fence = FENCE.match(line)
+        if fence_character:
+            outside_fence[index] = False
+            stripped = line.lstrip()
+            if (
+                stripped.startswith(fence_character * fence_length)
+                and not stripped.strip(fence_character).strip()
+            ):
+                fence_character = ""
+                fence_length = 0
+            continue
+        if fence:
+            marker = fence.group(1)
+            fence_character = marker[0]
+            fence_length = len(marker)
+            outside_fence[index] = False
+            continue
+
+        if (
+            index
+            and SETEXT_HEADING.match(line)
+            and outside_fence[index - 1]
+            and lines[index - 1].strip()
+            and not ATX_HEADING.match(lines[index - 1])
+        ):
+            headings.append(lines[index - 1].strip())
+            continue
+
+        match = ATX_HEADING.match(line)
+        if match:
+            heading = match.group(1) or ""
+            heading = re.sub(r"[ \t]+#+[ \t]*$", "", heading)
+            headings.append(heading.rstrip())
+
+    return headings
+
+
+def heading_anchors(text: str) -> set[str]:
+    occurrences: dict[str, int] = {}
+    anchors: set[str] = set()
+    for heading in markdown_headings(text):
+        original = github_slug(heading)
+        anchor = original
+        while anchor in occurrences:
+            occurrences[original] = occurrences.get(original, 0) + 1
+            anchor = f"{original}-{occurrences[original]}"
+        occurrences[anchor] = 0
+        anchors.add(anchor)
+    return anchors
 
 
 def validate_file(path: Path) -> list[str]:
@@ -68,8 +184,8 @@ def validate_file(path: Path) -> list[str]:
         if any(line.startswith(marker) for line in text.splitlines()):
             errors.append(f"{path.relative_to(ROOT)}: unresolved merge marker {marker}")
     for raw_destination in LINK.findall(text):
-        destination = destination_path(raw_destination)
-        if not destination or raw_destination.lstrip().startswith("#"):
+        destination, fragment = destination_parts(raw_destination)
+        if not destination and not fragment:
             continue
 
         parsed = urlparse(destination)
@@ -88,9 +204,13 @@ def validate_file(path: Path) -> list[str]:
         if parsed.scheme in {"mailto", "tel"}:
             continue
 
-        target = (path.parent / unquote(destination)).resolve()
+        target = (
+            path.resolve()
+            if not destination
+            else (path.parent / unquote(destination)).resolve()
+        )
         try:
-            target.relative_to(ROOT)
+            target_relative = target.relative_to(ROOT)
         except ValueError:
             errors.append(
                 f"{path.relative_to(ROOT)}: link leaves repository: {destination}"
@@ -100,6 +220,17 @@ def validate_file(path: Path) -> list[str]:
             errors.append(
                 f"{path.relative_to(ROOT)}: missing local link: {destination}"
             )
+            continue
+        if fragment and target.suffix.lower() == ".md" and target.is_file():
+            decoded_fragment = unquote(fragment)
+            target_text = (
+                text if target == path.resolve() else target.read_text(encoding="utf-8")
+            )
+            if decoded_fragment not in heading_anchors(target_text):
+                errors.append(
+                    f"{path.relative_to(ROOT)}: missing Markdown anchor in "
+                    f"{target_relative}: #{decoded_fragment}"
+                )
     return errors
 
 


### PR DESCRIPTION
## Problem and scope

`scripts/check_docs.py` removed fragments before validating links, so a link to a missing Markdown heading passed whenever the target file existed. This keeps the change scoped to repository-relative Markdown anchors.

Closes #40

## What changed

- validate same-file and cross-file Markdown fragments after percent-decoding
- generate GitHub-style slugs from ATX and Setext headings, including Unicode, punctuation/inline markup, and collision-safe duplicate suffixes
- ignore headings inside fenced code and continue ignoring external HTTP(S) and non-Markdown fragments
- add focused regressions while preserving traversal, owner, missing-file, merge-marker, and course checks

## Verification evidence

- [ ] `make lint`
- [ ] `make test`
- [ ] `make docs`
- [ ] `make evaluate`
- [ ] `make build`

Relevant output, screenshots, or evaluation case counts:

- `.venv\Scripts\ruff.exe check backend scripts` — passed
- `.venv\Scripts\ruff.exe format --check backend scripts` — passed (15 files already formatted)
- `.venv\Scripts\python.exe -m pytest -q backend/tests/test_check_docs.py` — 4 passed
- `.venv\Scripts\python.exe -m pytest -q backend/tests` — 30 passed, 1 skipped (Windows symlink capability)
- `.venv\Scripts\python.exe scripts/check_docs.py` — passed (46 Markdown files, 16 maintained lesson pages)
- `.venv\Scripts\python.exe scripts/evaluate_collaboration.py` — 3/3 passed
- targeted reverse mutation — disabling the missing-anchor branch made the diagnostic regression fail

GNU make, npm, and Docker were unavailable in this Windows environment. The exact Python/Ruff commands underlying the relevant Make targets are listed above; frontend and container gates were not run locally.

## Course and translation impact

- [x] No course behavior or explanation changed.
- [ ] English course/docs were updated.
- [ ] Maintained translations were updated or a follow-up issue is linked.
- [ ] New commands and links were run/checked.

Translation/review status: Not applicable; no course or documentation content changed.

## Security and privacy impact

- [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
- [ ] Untrusted text remains safely rendered and bounded.
- [ ] Authorization, retention, logging, and external-provider impact were considered where relevant.

Describe impact or write `none`: none; this is an offline, read-only documentation check.

## Compatibility, migration, and rollback

No runtime API, schema, or migration changes. CI continues to use the single `python3 scripts/check_docs.py` command. Revert this commit to restore the previous checker behavior.

## Known limitations

External HTTP(S) fragments and fragments on non-Markdown files remain intentionally unchecked.