### PR TITLE
fix(frontend): sync localized document metadata

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { App } from "./App";
 
@@ -25,7 +25,30 @@ function routeFetch(chatResponse: object) {
 beforeEach(() => {
   window.localStorage.clear();
   document.documentElement.lang = "en";
+  document.title = "Agent-Me Starter";
+  let description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+  if (!description) {
+    description = document.createElement("meta");
+    description.name = "description";
+    document.head.append(description);
+  }
+  description.content = "A grounded personal Q&A agent starter.";
   vi.restoreAllMocks();
+});
+
+it("sets useful localized metadata before the profile is available", () => {
+  vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => undefined)));
+
+  render(<App />);
+
+  expect(document.documentElement.lang).toBe("en");
+  expect(document.title).toBe(
+    "OPEN-SOURCE STARTER | Build an answer agent from knowledge you control.",
+  );
+  expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
+    "content",
+    expect.stringContaining("Add Markdown documents"),
+  );
 });
 
 it("submits a question and renders grounded sources", async () => {
@@ -63,7 +86,27 @@ it("switches locale, translates the interface, and remembers the choice", async 
   expect(screen.getByRole("heading", { name: "用你掌控的知识构建问答 Agent。" })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "提问" })).toBeDisabled();
   expect(document.documentElement.lang).toBe("zh-CN");
+  expect(document.title).toContain("用你掌控的知识构建问答 Agent。");
+  expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
+    "content",
+    expect.stringContaining("添加 Markdown 文档"),
+  );
   expect(window.localStorage.getItem("agent-me-locale")).toBe("zh-CN");
+});
+
+it("keeps localized metadata when profile loading fails", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+  render(<App />);
+  await userEvent.selectOptions(screen.getByRole("combobox", { name: "Language" }), "fr");
+
+  await waitFor(() => expect(document.documentElement.lang).toBe("fr"));
+  expect(document.title).toContain("Créez un agent de réponse");
+  expect(document.title.trim()).not.toBe("");
+  expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
+    "content",
+    expect.stringContaining("Ajoutez des documents Markdown"),
+  );
 });
 
 
@@ -137,6 +180,11 @@ it("applies the configured public profile and question limit", async () => {
 
   expect(await screen.findByText("Documentation Helper")).toBeInTheDocument();
   expect(screen.getByText("Answers from reviewed documentation.")).toBeInTheDocument();
+  expect(document.title).toContain("Documentation Helper");
+  expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
+    "content",
+    "Answers from reviewed documentation.",
+  );
   expect(screen.getByLabelText(/ask the example/i)).toHaveAttribute("maxlength", "42");
   expect(screen.getByText(/0 \/ 42 characters/)).toBeInTheDocument();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,19 @@ export function App() {
   }, [locale]);
 
   useEffect(() => {
+    const profileName = profile?.name.trim();
+    const profileDescription = profile?.description.trim();
+
+    document.documentElement.lang = locale;
+    document.title = `${profileName || text.projectLabel} | ${text.title}`;
+
+    const description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
+    if (description) {
+      description.content = profileDescription || text.intro;
+    }
+  }, [locale, profile, text]);
+
+  useEffect(() => {
     const controller = new AbortController();
     loadProfile(controller.signal)
       .then(setProfile)


### PR DESCRIPTION
## Summary
- synchronize the document language, title, and existing description meta with the selected locale
- use trimmed public profile metadata when available and localized copy as a non-empty fallback
- cover initial metadata, locale changes, profile success, and profile failure in the frontend tests

Closes #33

## Testing
- `npm test` (22 passed)
- `npm run lint`
- `npm run typecheck`
- `npm run build`