### PR TITLE
fix: add stable semantic request limit codes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -38,6 +38,23 @@ _PROVIDER_ERROR_MESSAGES = {
     "provider_request_failed": "Answer provider rejected the request.",
     "provider_unavailable": "Answer provider is temporarily unavailable.",
 }
+
+
+class SemanticLimitError(Exception):
+    """A route-level size limit with a stable client-facing code."""
+
+    def __init__(self, *, code: str, detail: str) -> None:
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+
+
+@app.exception_handler(SemanticLimitError)
+async def semantic_limit_error(_: Request, error: SemanticLimitError) -> JSONResponse:
+    return JSONResponse(
+        status_code=413,
+        content={"detail": error.detail, "code": error.code},
+    )
 
 
 @app.exception_handler(ProviderError)
@@ -97,9 +114,15 @@ async def profile(config: Settings = Depends(get_settings)) -> ProfileResponse:
 @app.post("/api/v1/chat", response_model=ChatResponse)
 async def chat(payload: ChatRequest, config: Settings = Depends(get_settings)) -> ChatResponse:
     if len(payload.question) > config.max_question_chars:
-        raise HTTPException(status_code=413, detail="question exceeds configured limit")
+        raise SemanticLimitError(
+            code="question_too_large",
+            detail="question exceeds configured limit",
+        )
     if sum(len(turn.content) for turn in payload.history) > config.max_history_chars:
-        raise HTTPException(status_code=413, detail="history exceeds configured limit")
+        raise SemanticLimitError(
+            code="history_too_large",
+            detail="history exceeds configured limit",
+        )
     matches = KnowledgeBase(
         config.knowledge_dir, max_document_bytes=config.max_document_bytes
     ).search(payload.question)
@@ -130,7 +153,10 @@ async def collaborate(
     config: Settings = Depends(get_settings),
 ) -> CollaborationResponse:
     if len(payload.question) > config.max_question_chars:
-        raise HTTPException(status_code=413, detail="question exceeds configured limit")
+        raise SemanticLimitError(
+            code="question_too_large",
+            detail="question exceeds configured limit",
+        )
     matches = KnowledgeBase(
         config.knowledge_dir, max_document_bytes=config.max_document_bytes
     ).search(payload.question)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -158,6 +158,24 @@ async def test_blank_and_unknown_fields_are_rejected(client: httpx.AsyncClient) 
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("endpoint", ["/api/v1/chat", "/api/v1/collaborate"])
+async def test_question_total_limit_has_a_stable_error_code(
+    client: httpx.AsyncClient, endpoint: str
+) -> None:
+    settings = get_settings()
+    original = settings.max_question_chars
+    settings.max_question_chars = 5
+    try:
+        response = await client.post(endpoint, json={"question": "123456"})
+    finally:
+        settings.max_question_chars = original
+
+    assert response.status_code == 413
+    assert response.json()["code"] == "question_too_large"
+    assert isinstance(response.json()["detail"], str)
+
+
+@pytest.mark.anyio
 async def test_history_total_limit_is_enforced(client: httpx.AsyncClient) -> None:
     settings = get_settings()
     original = settings.max_history_chars
@@ -174,7 +192,8 @@ async def test_history_total_limit_is_enforced(client: httpx.AsyncClient) -> Non
         settings.max_history_chars = original
 
     assert response.status_code == 413
-    assert response.json() == {"detail": "history exceeds configured limit"}
+    assert response.json()["code"] == "history_too_large"
+    assert isinstance(response.json()["detail"], str)
 
 
 @pytest.mark.anyio

--- a/docs/API.md
+++ b/docs/API.md
@@ -62,6 +62,27 @@ The actual response always contains planner, researcher, critic, and writer stag
 
 When retrieval finds no evidence, `grounded` is `false`, the critic outcome is `blocked`, and the writer returns the fixed insufficient-evidence message with zero citations.
 
+## Request-size errors
+
+Size-limit failures use HTTP `413` and the existing flat error shape:
+
+```json
+{
+  "detail": "question exceeds configured limit",
+  "code": "question_too_large"
+}
+```
+
+Clients should branch on `code`, not on the human-readable `detail` text:
+
+| Limit | Affected endpoints | Code |
+| --- | --- | --- |
+| Raw HTTP body exceeds `MAX_REQUEST_BODY_BYTES` | All endpoints | `request_body_too_large` |
+| Normalized question exceeds `MAX_QUESTION_CHARS` | `/api/v1/chat`, `/api/v1/collaborate` | `question_too_large` |
+| Aggregate history content exceeds `MAX_HISTORY_CHARS` | `/api/v1/chat` | `history_too_large` |
+
+Malformed request schemas, unknown fields, invalid roles, and blank strings continue to use FastAPI's standard HTTP `422` validation response rather than these size-limit codes.
+
 
 ## Provider failures
 


### PR DESCRIPTION
## Problem and scope

Application-level question and history limits returned only English `detail` strings, while the raw request-body middleware already exposed a stable machine-readable code. This made clients parse prose to distinguish three different HTTP 413 cases.

Closes #36

## What changed

- add a focused route-level limit exception that preserves the existing flat `{detail, code}` response shape
- return `question_too_large` from both chat and collaboration question limits
- return `history_too_large` from the chat aggregate-history limit
- keep `request_body_too_large` and FastAPI's standard 422 validation behavior unchanged
- add endpoint regression coverage and document all three size-limit codes

## Verification evidence

- [x] `make lint`
- [x] `make test`
- [x] `make docs`
- [x] `make evaluate`
- [x] `make build`

Relevant output, screenshots, or evaluation case counts:

- Ruff check and format check passed across `backend` and `scripts`
- backend: 33 tests passed
- frontend: 22 tests passed
- documentation: 45 Markdown files and 16 maintained lesson pages passed
- collaboration evaluation: 3/3 cases passed
- both Compose images built successfully

## Course and translation impact

- [x] No course behavior or explanation changed.
- [x] English course/docs were updated.
- [ ] Maintained translations were updated or a follow-up issue is linked.
- [x] New commands and links were run/checked.

Translation/review status: No maintained course lesson changed. `docs/API.md` is the canonical English API reference and now documents the stable codes.

## Security and privacy impact

- [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
- [x] Untrusted text remains safely rendered and bounded.
- [x] Authorization, retention, logging, and external-provider impact were considered where relevant.

Describe impact or write `none`: The response details and codes are fixed server constants. No request content, provider detail, or internal path is added to errors.

## Compatibility, migration, and rollback

This is an additive API compatibility improvement: HTTP status 413 and the existing human-readable `detail` remain unchanged, while semantic limit failures gain a top-level `code`. No database or configuration migration is required. Revert commit `143cba9` to restore the previous response bodies.

## Known limitations

- Per-message Pydantic field limits still use the standard HTTP 422 validation response; this PR changes only configured aggregate/semantic 413 limits.
