### PR TITLE
chore(docker): pin base images by immutable digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule: { interval: weekly }
+  - package-ecosystem: docker
+    directory: /backend
+    schedule: { interval: weekly }
+  - package-ecosystem: docker
+    directory: /frontend
+    schedule: { interval: weekly }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim@sha256:09f7da3bc104798d0afb40bc08d23ab2da20a76130cec1f2ef170848f5d85217 AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY backend/pyproject.toml /app/pyproject.toml

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -6,7 +6,7 @@ COPY . .
 ARG VITE_API_BASE_URL=/api
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build
-FROM nginx:1.27-alpine
+FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## Problem and scope

<!-- What problem does this solve? Keep the change focused. Link the issue. -->

Closes #37

The current Dockerfiles reference mutable base-image tags (`python:3.12-slim`, `node:22-alpine`, and `nginx:1.27-alpine`). Because these tags can resolve to different image contents over time, rebuilding the same repository commit can produce different container base layers without any corresponding repository change.

This PR addresses Docker base-image reproducibility and update visibility while remaining strictly scoped to the existing backend and frontend Dockerfiles.

## What changed

* Pinned every existing Docker `FROM` image to an immutable SHA-256 digest while retaining the existing human-readable image tag.

  * `python:3.12-slim` in `backend/Dockerfile`
  * `node:22-alpine` in the frontend build stage
  * `nginx:1.27-alpine` in the frontend runtime stage
* Added weekly Dependabot Docker configuration for `/backend`.
* Added weekly Dependabot Docker configuration for `/frontend`.
* Preserved the existing pip, npm, and GitHub Actions Dependabot configuration.
* Preserved all existing Docker Compose deployment hardening:

  * non-root backend execution via `USER 65532:65532`
  * read-only container filesystems
  * `cap_drop: [ALL]`
  * existing frontend `cap_add` capability set
  * `no-new-privileges:true`
  * existing tmpfs mounts
* Left `docker-compose.yml` unchanged.
* No application dependencies, application source code, Docker service configuration, or unrelated infrastructure behavior was modified.
* No Python, Node, or Nginx major-version upgrade is included; only immutable digest pins were added to the existing image references.
* No registry credentials, generated secrets, or other sensitive artifacts were added.

## Verification evidence

<!-- List commands actually run and summarize results. Do not check a box you did not run. -->

* [x] `docker compose config --quiet`
* [x] `docker compose build`
* [x] Backend `/health` check
* [x] Backend `/ready` check
* [x] Existing collaboration smoke check
* [x] Existing frontend smoke check
* [x] `git diff --check`
* [x] Final Git diff reviewed for unrelated changes
* [ ] make lint 
* [ ] make test
* [ ] make docs 
* [ ] make evaluate
* [ ] make build

Results:

* `docker compose config --quiet` completed successfully.
* Both backend and frontend Docker images built successfully using the pinned base-image digests.
* `/health` returned successfully.
* `/ready` returned successfully.
* Existing collaboration smoke checks passed.
* Existing frontend smoke checks passed.
* `git diff --check` completed without whitespace errors.
* Final diff was reviewed to confirm the PR is limited to the three intended files: `.github/dependabot.yml`, `backend/Dockerfile`, and `frontend/Dockerfile.
* Existing non-root, read-only, capability-dropping, and `no-new-privileges` hardening was verified to remain unchanged.

### Digest refresh and verification procedure

Maintainers can refresh a pinned base-image digest by inspecting the existing image tag with Docker Buildx:

```bash
docker buildx imagetools inspect python:3.12-slim
docker buildx imagetools inspect node:22-alpine
docker buildx imagetools inspect nginx:1.27-alpine
```

The reported top-level multi-platform image index `Digest` should be used for the corresponding `@sha256:...` pin while retaining the existing image tag.

After a digest refresh, verify the update with:

```bash
docker compose config --quiet
docker compose build
```

and then run the existing health/readiness, collaboration, and frontend smoke checks before merging the update. Dependabot will also monitor both Dockerfiles on the configured weekly cadence and surface future Docker updates as reviewable pull requests.

## Course and translation impact

* [x] No course behavior or explanation changed.
* [ ] English course/docs were updated.
* [ ] Maintained translations were updated or a follow-up issue is linked.
* [x] New commands and links were run/checked.

Translation/review status:

No course, translation, or user-facing documentation behavior is affected by this infrastructure-only change. The Docker digest refresh procedure is documented above for maintainers.

## Security and privacy impact

* [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
* [x] Untrusted text remains safely rendered and bounded.
* [x] Authorization, retention, logging, and external-provider impact were considered where relevant.

Describe impact or write `none`:

This change has no application-level authorization, retention, logging, or external-provider behavior impact. It improves container supply-chain integrity by preventing mutable Docker tags from silently resolving to different base-image contents between builds.

Existing container hardening is explicitly preserved, including non-root execution, read-only filesystems, capability dropping, restricted capability additions, and `no-new-privileges`.

## Compatibility, migration, and rollback

No application API, database schema, dependency interface, or runtime configuration changes are introduced.

No migration is required.

The existing Docker image tags and major versions remain unchanged; only immutable digest constraints were added.

Rollback consists of reverting the Dockerfile digest changes and Dependabot Docker entries if required. A digest update can also be independently reverted to the previously reviewed digest without changing application code.

## Known limitations

* Docker base-image digests are immutable, but the corresponding image contents are intentionally fixed until a subsequent digest update is reviewed and merged.
* Dependabot Docker updates are configured on a weekly cadence; newly published base-image updates are therefore surfaced according to that schedule rather than immediately.
* Digest refreshes still require the Docker Compose configuration, image builds, and existing application smoke checks to be verified before merging.