### PR TITLE
fix(eval): reject duplicate fixture case IDs (#56)

### DIFF
--- a/backend/tests/test_evaluate_duplicate_ids.py
+++ b/backend/tests/test_evaluate_duplicate_ids.py
@@ -1,91 +1,98 @@
-﻿"""Unit tests for evaluate_collaboration.load_cases duplicate-ID detection."""
+"""Tests for evaluation-fixture case ID validation."""
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import re
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-# Make the scripts package importable without installing it.
-SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
-sys.path.insert(0, str(SCRIPTS_DIR))
-
-from evaluate_collaboration import load_cases  # noqa: E402
-
-
-def _write_cases(tmp_path: Path, cases: list[dict]) -> Path:
-    p = tmp_path / "cases.json"
-    p.write_text(json.dumps(cases), encoding="utf-8")
-    return p
+EVALUATOR_PATH = Path(__file__).resolve().parents[2] / "scripts" / "evaluate_collaboration.py"
+EVALUATOR_SPEC = importlib.util.spec_from_file_location("evaluate_collaboration", EVALUATOR_PATH)
+assert EVALUATOR_SPEC is not None and EVALUATOR_SPEC.loader is not None
+evaluator = importlib.util.module_from_spec(EVALUATOR_SPEC)
+sys.modules[EVALUATOR_SPEC.name] = evaluator
+EVALUATOR_SPEC.loader.exec_module(evaluator)
 
 
-# ---------------------------------------------------------------------------
-# Happy paths
-# ---------------------------------------------------------------------------
+def _case(case_id: str, *, grounded: bool = True) -> dict[str, Any]:
+    return {
+        "id": case_id,
+        "question": f"Public example question for {case_id}",
+        "expected_grounded": grounded,
+    }
 
 
-def test_valid_fixture_is_accepted(tmp_path: Path) -> None:
-    """Three cases with distinct IDs should load in order without error."""
-    cases = [
-        {"id": "alpha", "question": "What is alpha?", "expected_grounded": True},
-        {"id": "beta", "question": "What is beta?", "expected_grounded": False},
-        {"id": "gamma", "question": "What is gamma?", "expected_grounded": True},
-    ]
-    result = load_cases(_write_cases(tmp_path, cases))
-    assert [c["id"] for c in result] == ["alpha", "beta", "gamma"]
+def _write_cases(tmp_path: Path, cases: list[dict[str, Any]]) -> Path:
+    path = tmp_path / "cases.json"
+    path.write_text(json.dumps(cases), encoding="utf-8")
+    return path
 
 
-def test_single_case_is_accepted(tmp_path: Path) -> None:
-    cases = [{"id": "solo", "question": "Only one?", "expected_grounded": False}]
-    result = load_cases(_write_cases(tmp_path, cases))
-    assert len(result) == 1
+def test_valid_fixture_preserves_case_order(tmp_path: Path) -> None:
+    cases = [_case("alpha"), _case("beta", grounded=False), _case("gamma")]
+
+    result = evaluator.load_cases(_write_cases(tmp_path, cases))
+
+    assert [case["id"] for case in result] == ["alpha", "beta", "gamma"]
 
 
-# ---------------------------------------------------------------------------
-# Duplicate-ID rejection
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("case_ids", "first_position", "duplicate_position"),
+    [
+        (["unique", "duplicate", "duplicate"], 1, 2),
+        (["duplicate", "beta", "gamma", "duplicate"], 0, 3),
+    ],
+)
+def test_duplicate_ids_report_the_id_and_zero_based_positions(
+    tmp_path: Path,
+    case_ids: list[str],
+    first_position: int,
+    duplicate_position: int,
+) -> None:
+    path = _write_cases(tmp_path, [_case(case_id) for case_id in case_ids])
+    expected = (
+        f"duplicate case id 'duplicate' at zero-based positions "
+        f"{first_position} and {duplicate_position}"
+    )
+
+    with pytest.raises(ValueError, match=re.escape(expected)):
+        evaluator.load_cases(path)
 
 
-def test_adjacent_duplicate_ids_are_rejected(tmp_path: Path) -> None:
-    """Duplicate IDs at positions 1 and 2 (adjacent) must be caught."""
-    cases = [
-        {"id": "unique", "question": "First question.", "expected_grounded": True},
-        {"id": "dup", "question": "Second question.", "expected_grounded": False},
-        {"id": "dup", "question": "Third question.", "expected_grounded": True},
-    ]
-    with pytest.raises(ValueError, match="duplicate case id .dup. at positions 1 and 2"):
-        load_cases(_write_cases(tmp_path, cases))
+def test_duplicate_fixture_fails_before_knowledge_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write_cases(tmp_path, [_case("duplicate"), _case("duplicate")])
+
+    class UnexpectedKnowledgeBase:
+        def __init__(self, *_: object, **__: object) -> None:
+            raise AssertionError("knowledge loading must not start for an invalid fixture")
+
+    monkeypatch.setattr(evaluator, "KnowledgeBase", UnexpectedKnowledgeBase)
+
+    with pytest.raises(ValueError, match="duplicate case id"):
+        evaluator.evaluate(path, tmp_path / "knowledge")
 
 
-def test_non_adjacent_duplicate_ids_are_rejected(tmp_path: Path) -> None:
-    """Duplicate IDs at positions 0 and 3 (non-adjacent) must be caught."""
-    cases = [
-        {"id": "dup", "question": "First question.", "expected_grounded": True},
-        {"id": "b", "question": "Second question.", "expected_grounded": False},
-        {"id": "c", "question": "Third question.", "expected_grounded": True},
-        {"id": "dup", "question": "Fourth question.", "expected_grounded": False},
-    ]
-    with pytest.raises(ValueError, match="duplicate case id .dup. at positions 0 and 3"):
-        load_cases(_write_cases(tmp_path, cases))
+def test_cli_returns_setup_error_for_duplicate_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write_cases(tmp_path, [_case("duplicate"), _case("duplicate")])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["evaluate_collaboration.py", "--cases", str(path), "--knowledge-dir", str(tmp_path)],
+    )
 
-
-def test_duplicate_error_names_the_id(tmp_path: Path) -> None:
-    """The error message must include the duplicated ID value."""
-    cases = [
-        {"id": "my-case-id", "question": "Q1", "expected_grounded": True},
-        {"id": "my-case-id", "question": "Q2", "expected_grounded": True},
-    ]
-    with pytest.raises(ValueError, match="my-case-id"):
-        load_cases(_write_cases(tmp_path, cases))
-
-
-def test_no_cases_executed_after_duplicate_detected(tmp_path: Path) -> None:
-    """load_cases must raise before returning, so no cases are silently processed."""
-    cases = [
-        {"id": "x", "question": "Q1", "expected_grounded": True},
-        {"id": "x", "question": "Q2", "expected_grounded": False},
-    ]
-    with pytest.raises(ValueError):
-        load_cases(_write_cases(tmp_path, cases))
+    assert evaluator.main() == 2
+    assert (
+        "evaluation setup failed: duplicate case id 'duplicate' at zero-based positions 0 and 1"
+        in capsys.readouterr().err
+    )

--- a/backend/tests/test_evaluate_duplicate_ids.py
+++ b/backend/tests/test_evaluate_duplicate_ids.py
@@ -1,0 +1,91 @@
+﻿"""Unit tests for evaluate_collaboration.load_cases duplicate-ID detection."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the scripts package importable without installing it.
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from evaluate_collaboration import load_cases  # noqa: E402
+
+
+def _write_cases(tmp_path: Path, cases: list[dict]) -> Path:
+    p = tmp_path / "cases.json"
+    p.write_text(json.dumps(cases), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_valid_fixture_is_accepted(tmp_path: Path) -> None:
+    """Three cases with distinct IDs should load in order without error."""
+    cases = [
+        {"id": "alpha", "question": "What is alpha?", "expected_grounded": True},
+        {"id": "beta", "question": "What is beta?", "expected_grounded": False},
+        {"id": "gamma", "question": "What is gamma?", "expected_grounded": True},
+    ]
+    result = load_cases(_write_cases(tmp_path, cases))
+    assert [c["id"] for c in result] == ["alpha", "beta", "gamma"]
+
+
+def test_single_case_is_accepted(tmp_path: Path) -> None:
+    cases = [{"id": "solo", "question": "Only one?", "expected_grounded": False}]
+    result = load_cases(_write_cases(tmp_path, cases))
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-ID rejection
+# ---------------------------------------------------------------------------
+
+
+def test_adjacent_duplicate_ids_are_rejected(tmp_path: Path) -> None:
+    """Duplicate IDs at positions 1 and 2 (adjacent) must be caught."""
+    cases = [
+        {"id": "unique", "question": "First question.", "expected_grounded": True},
+        {"id": "dup", "question": "Second question.", "expected_grounded": False},
+        {"id": "dup", "question": "Third question.", "expected_grounded": True},
+    ]
+    with pytest.raises(ValueError, match="duplicate case id .dup. at positions 1 and 2"):
+        load_cases(_write_cases(tmp_path, cases))
+
+
+def test_non_adjacent_duplicate_ids_are_rejected(tmp_path: Path) -> None:
+    """Duplicate IDs at positions 0 and 3 (non-adjacent) must be caught."""
+    cases = [
+        {"id": "dup", "question": "First question.", "expected_grounded": True},
+        {"id": "b", "question": "Second question.", "expected_grounded": False},
+        {"id": "c", "question": "Third question.", "expected_grounded": True},
+        {"id": "dup", "question": "Fourth question.", "expected_grounded": False},
+    ]
+    with pytest.raises(ValueError, match="duplicate case id .dup. at positions 0 and 3"):
+        load_cases(_write_cases(tmp_path, cases))
+
+
+def test_duplicate_error_names_the_id(tmp_path: Path) -> None:
+    """The error message must include the duplicated ID value."""
+    cases = [
+        {"id": "my-case-id", "question": "Q1", "expected_grounded": True},
+        {"id": "my-case-id", "question": "Q2", "expected_grounded": True},
+    ]
+    with pytest.raises(ValueError, match="my-case-id"):
+        load_cases(_write_cases(tmp_path, cases))
+
+
+def test_no_cases_executed_after_duplicate_detected(tmp_path: Path) -> None:
+    """load_cases must raise before returning, so no cases are silently processed."""
+    cases = [
+        {"id": "x", "question": "Q1", "expected_grounded": True},
+        {"id": "x", "question": "Q2", "expected_grounded": False},
+    ]
+    with pytest.raises(ValueError):
+        load_cases(_write_cases(tmp_path, cases))

--- a/course/06-evaluation/README.md
+++ b/course/06-evaluation/README.md
@@ -46,12 +46,14 @@ No single layer substitutes for all others.
 }
 ```
 
-The evaluator validates exact keys and value types, runs retrieval and orchestration, records source
+The evaluator enforces unique case IDs, validates exact keys and value types, runs retrieval and orchestration, records source
 count and critic outcome, and exits:
 
 - `0` when all expectations pass;
 - `1` when behavior disagrees with labels;
 - `2` when fixture or environment setup is invalid.
+
+Stable, unique case IDs are essential for regression tracking across runs, making sure individual test cases can be reliably mapped over time and diffed in automated CI reports without ambiguity.
 
 That distinction helps CI separate a product regression from a broken evaluation file.
 

--- a/course/06-evaluation/README.md
+++ b/course/06-evaluation/README.md
@@ -46,14 +46,15 @@ No single layer substitutes for all others.
 }
 ```
 
-The evaluator enforces unique case IDs, validates exact keys and value types, runs retrieval and orchestration, records source
-count and critic outcome, and exits:
+The evaluator enforces unique case IDs, validates exact keys and value types, runs retrieval and
+orchestration, records source count and critic outcome, and exits:
 
 - `0` when all expectations pass;
 - `1` when behavior disagrees with labels;
 - `2` when fixture or environment setup is invalid.
 
-Stable, unique case IDs are essential for regression tracking across runs, making sure individual test cases can be reliably mapped over time and diffed in automated CI reports without ambiguity.
+Stable, unique case IDs let CI map a case across runs and compare regressions without confusing two
+different examples that share a label.
 
 That distinction helps CI separate a product regression from a broken evaluation file.
 

--- a/scripts/evaluate_collaboration.py
+++ b/scripts/evaluate_collaboration.py
@@ -29,6 +29,7 @@ def load_cases(path: Path) -> list[dict[str, Any]]:
     if not isinstance(data, list) or not data:
         raise ValueError("evaluation cases must be a non-empty JSON array")
     cases: list[dict[str, Any]] = []
+    seen_ids: dict[str, int] = {}
     for index, item in enumerate(data):
         if not isinstance(item, dict) or set(item) != {
             "id",
@@ -44,6 +45,12 @@ def load_cases(path: Path) -> list[dict[str, Any]]:
             or not isinstance(item["expected_grounded"], bool)
         ):
             raise ValueError(f"case {index} has invalid values")
+        case_id = item["id"]
+        if case_id in seen_ids:
+            raise ValueError(
+                f"duplicate case id {case_id!r} at positions {seen_ids[case_id]} and {index}"
+            )
+        seen_ids[case_id] = index
         cases.append(item)
     return cases
 

--- a/scripts/evaluate_collaboration.py
+++ b/scripts/evaluate_collaboration.py
@@ -48,7 +48,8 @@ def load_cases(path: Path) -> list[dict[str, Any]]:
         case_id = item["id"]
         if case_id in seen_ids:
             raise ValueError(
-                f"duplicate case id {case_id!r} at positions {seen_ids[case_id]} and {index}"
+                f"duplicate case id {case_id!r} at zero-based positions "
+                f"{seen_ids[case_id]} and {index}"
             )
         seen_ids[case_id] = index
         cases.append(item)


### PR DESCRIPTION
Closes #56.

### Summary of Changes

1. **`scripts/evaluate_collaboration.py`**:
   - `load_cases()` now records seen case IDs in a dictionary and raises an actionable `ValueError` when a duplicate is found (naming the duplicate ID and both 0-based positions).
   - This prevents duplicate case IDs from running or showing indistinguishable rows in test output.

2. **`course/06-evaluation/README.md`**:
   - Added a note to Lesson 06 explaining why stable unique case IDs matter for regression tracking and CI diffing across runs.

3. **`backend/tests/test_evaluate_duplicate_ids.py`**:
   - Added focused unit tests verifying:
     - Valid fixtures with unique IDs load cleanly and maintain order.
     - Adjacent duplicate IDs are rejected.
     - Non-adjacent duplicate IDs are rejected.
     - Diagnostics name the duplicated ID.
     - Evaluation halts before executing any cases upon invalid fixture loading.

### Verification
- `pytest backend/tests/ -v` (38 passed, 1 skipped)
- `python scripts/check_docs.py` (passed)
- `python scripts/evaluate_collaboration.py` (3/3 passed)
