### PR TITLE
fix: make planner handoff drive retrieval

### DIFF
--- a/backend/app/collaboration.py
+++ b/backend/app/collaboration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import Literal, Protocol, TypeAlias
 from uuid import uuid4
 
 from .knowledge import Match
@@ -21,6 +21,7 @@ def _tokens(value: str) -> set[str]:
 
 @dataclass(frozen=True)
 class Plan:
+    retrieval_query: str
     tasks: tuple[str, ...]
     query_term_count: int
 
@@ -61,25 +62,34 @@ class CollaborationResult:
     trace: tuple[StageTrace, ...]
 
 
+class Retriever(Protocol):
+    def search(self, question: str, *, limit: int = 4) -> list[Match]: ...
+
+
 class PlannerAgent:
     name: AgentName = "planner"
 
     def run(self, question: str) -> Plan:
+        retrieval_query = question.strip()
         return Plan(
+            retrieval_query=retrieval_query,
             tasks=(
                 "Retrieve evidence from the configured knowledge base.",
                 "Check whether the evidence supports the requested answer.",
                 "Write a concise answer with source-path citations.",
             ),
-            query_term_count=len(_tokens(question)),
+            query_term_count=len(_tokens(retrieval_query)),
         )
 
 
 class ResearcherAgent:
     name: AgentName = "researcher"
 
-    def run(self, matches: list[Match]) -> EvidenceBundle:
-        return EvidenceBundle(matches=tuple(matches))
+    def __init__(self, retriever: Retriever) -> None:
+        self.retriever = retriever
+
+    def run(self, plan: Plan) -> EvidenceBundle:
+        return EvidenceBundle(matches=tuple(self.retriever.search(plan.retrieval_query)))
 
 
 class CriticAgent:
@@ -124,19 +134,20 @@ class CollaborationOrchestrator:
     def __init__(
         self,
         *,
+        retriever: Retriever,
         planner: PlannerAgent | None = None,
         researcher: ResearcherAgent | None = None,
         critic: CriticAgent | None = None,
         writer: WriterAgent | None = None,
     ) -> None:
         self.planner = planner or PlannerAgent()
-        self.researcher = researcher or ResearcherAgent()
+        self.researcher = researcher or ResearcherAgent(retriever)
         self.critic = critic or CriticAgent()
         self.writer = writer or WriterAgent()
 
-    def run(self, *, question: str, matches: list[Match]) -> CollaborationResult:
+    def run(self, *, question: str) -> CollaborationResult:
         plan = self.planner.run(question)
-        evidence = self.researcher.run(matches)
+        evidence = self.researcher.run(plan)
         critique = self.critic.run(question, evidence)
         written = self.writer.run(evidence, critique)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -157,10 +157,9 @@ async def collaborate(
             code="question_too_large",
             detail="question exceeds configured limit",
         )
-    matches = KnowledgeBase(
-        config.knowledge_dir, max_document_bytes=config.max_document_bytes
-    ).search(payload.question)
-    result = CollaborationOrchestrator().run(question=payload.question, matches=matches)
+    result = CollaborationOrchestrator(
+        retriever=KnowledgeBase(config.knowledge_dir, max_document_bytes=config.max_document_bytes)
+    ).run(question=payload.question)
     return CollaborationResponse(
         run_id=result.run_id,
         workflow=result.workflow,

--- a/backend/tests/test_collaboration.py
+++ b/backend/tests/test_collaboration.py
@@ -1,4 +1,4 @@
-from app.collaboration import CollaborationOrchestrator
+from app.collaboration import CollaborationOrchestrator, Plan, PlannerAgent
 from app.knowledge import Document, Match
 
 
@@ -10,10 +10,29 @@ def match(path: str = "profile.md", excerpt: str = "The agent plans from user go
     )
 
 
+class StubRetriever:
+    def __init__(self, matches: list[Match]) -> None:
+        self.matches = matches
+        self.queries: list[str] = []
+
+    def search(self, question: str, *, limit: int = 4) -> list[Match]:
+        self.queries.append(question)
+        return self.matches[:limit]
+
+
+class RewritingPlanner(PlannerAgent):
+    def run(self, question: str) -> Plan:
+        return Plan(
+            retrieval_query="rewritten retrieval query",
+            tasks=("Retrieve evidence for the rewritten query.",),
+            query_term_count=3,
+        )
+
+
 def test_role_handoffs_are_ordered_and_grounded() -> None:
-    result = CollaborationOrchestrator().run(
-        question="How does the agent plan from user goals?",
-        matches=[match()],
+    retriever = StubRetriever([match()])
+    result = CollaborationOrchestrator(retriever=retriever).run(
+        question="How does the agent plan from user goals?"
     )
 
     assert result.run_id.startswith("run_")
@@ -29,10 +48,11 @@ def test_role_handoffs_are_ordered_and_grounded() -> None:
     assert "[profile.md]" in result.answer
     assert result.trace[1].metrics == {"evidence_count": 1, "document_count": 1}
     assert result.trace[2].metrics["approved"] is True
+    assert retriever.queries == ["How does the agent plan from user goals?"]
 
 
 def test_critic_blocks_unsupported_synthesis() -> None:
-    result = CollaborationOrchestrator().run(question="Unknown fact?", matches=[])
+    result = CollaborationOrchestrator(retriever=StubRetriever([])).run(question="Unknown fact?")
 
     assert result.grounded is False
     assert result.matches == ()
@@ -43,9 +63,20 @@ def test_critic_blocks_unsupported_synthesis() -> None:
 
 
 def test_run_ids_are_unique_and_server_controlled() -> None:
-    orchestrator = CollaborationOrchestrator()
-    first = orchestrator.run(question="Plan?", matches=[match()])
-    second = orchestrator.run(question="Plan?", matches=[match()])
+    orchestrator = CollaborationOrchestrator(retriever=StubRetriever([match()]))
+    first = orchestrator.run(question="Plan?")
+    second = orchestrator.run(question="Plan?")
 
     assert first.run_id != second.run_id
     assert len(first.run_id) == len("run_") + 32
+
+
+def test_planner_output_controls_the_researcher_query() -> None:
+    retriever = StubRetriever([match()])
+    result = CollaborationOrchestrator(
+        retriever=retriever,
+        planner=RewritingPlanner(),
+    ).run(question="original user question")
+
+    assert retriever.queries == ["rewritten retrieval query"]
+    assert result.trace[0].metrics == {"task_count": 1, "query_term_count": 3}

--- a/course/03-role-design/README.md
+++ b/course/03-role-design/README.md
@@ -42,8 +42,8 @@ function until a real boundary appears.
 
 | Role | Receives | Produces | Owns | Does not own |
 | --- | --- | --- | --- | --- |
-| Planner | normalized question | `Plan` | evidence-first task outline | retrieval results |
-| Researcher | ranked `Match` objects | `EvidenceBundle` | evidence packaging | final approval |
+| Planner | normalized question | `Plan` | retrieval intent and evidence-first task outline | retrieval results |
+| Researcher | `Plan` + injected retriever | `EvidenceBundle` | retrieval and evidence packaging | final approval |
 | Critic | question + evidence | `Critique` | grounded/block decision | answer wording |
 | Writer | evidence + critique | `WrittenAnswer` | response composition | source discovery |
 
@@ -127,9 +127,10 @@ Record:
 
 ### Step 3 — test dependency substitution
 
-`CollaborationOrchestrator` accepts role instances in its constructor. Create a small test double
-for one role and verify the orchestrator uses it. The double must return the same typed artifact;
-do not bypass the contract with an arbitrary dictionary.
+`CollaborationOrchestrator` accepts a retriever and optional role instances in its constructor.
+Create a planner test double that changes `Plan.retrieval_query`, then use a recording retriever to
+verify that the researcher searches for exactly that value. Do not bypass the contract with an
+arbitrary dictionary.
 
 This demonstrates an important property: **separate roles are useful when behavior can be changed
 or tested at a boundary**.
@@ -179,10 +180,11 @@ Choose one proposed role: verifier, router, privacy reviewer, or formatter. Writ
 - expected cost and latency;
 - rejection criteria if it adds no value.
 
-### Intermediate — remove a ceremonial role
+### Intermediate — detect a ceremonial role
 
-Imagine the planner always returns the same three tasks and no downstream role reads them. Argue
-for retaining, changing, or removing it. Base the decision on observable behavior, not the role name.
+Temporarily change the planner's `retrieval_query` while leaving the original HTTP question intact.
+Write a test that fails if the researcher ignores the plan and searches for the original question.
+Then explain what evidence would justify retaining or removing the planner boundary.
 
 ### Advanced — parallel research design
 

--- a/course/04-typed-orchestration/README.md
+++ b/course/04-typed-orchestration/README.md
@@ -46,7 +46,7 @@ contain only stable, safe, caller-relevant information.
 
 | Artifact | Important invariants |
 | --- | --- |
-| `Plan` | tasks are ordered; query count is nonnegative |
+| `Plan` | retrieval query is normalized; tasks are ordered; query count is nonnegative |
 | `EvidenceBundle` | matches preserve rank order; every source came from retrieval |
 | `Critique` | grounded decision and bounded coverage describe current evidence |
 | `WrittenAnswer` | blocked evidence yields zero citations |
@@ -79,7 +79,7 @@ Run:
 from dataclasses import FrozenInstanceError
 from app.collaboration import Plan
 
-plan = Plan(tasks=("retrieve",), query_term_count=1)
+plan = Plan(retrieval_query="agent planning", tasks=("retrieve",), query_term_count=2)
 try:
     plan.query_term_count = 99
 except FrozenInstanceError as error:

--- a/course/translations/zh-CN/03-role-design/README.md
+++ b/course/translations/zh-CN/03-role-design/README.md
@@ -31,8 +31,8 @@
 
 | 角色 | 输入 | 输出 | 负责 | 不负责 |
 | --- | --- | --- | --- | --- |
-| Planner | 规范化问题 | `Plan` | 证据优先任务 | 检索结果 |
-| Researcher | 排序 `Match` | `EvidenceBundle` | 封装证据 | 最终批准 |
+| Planner | 规范化问题 | `Plan` | 检索意图与证据优先任务 | 检索结果 |
+| Researcher | `Plan` + 注入的 retriever | `EvidenceBundle` | 执行检索并封装证据 | 最终批准 |
 | Critic | 问题 + 证据 | `Critique` | grounded/block 决定 | 回答措辞 |
 | Writer | 证据 + critique | `WrittenAnswer` | 组合回答 | 发现来源 |
 
@@ -69,7 +69,7 @@ curl --silent http://localhost:8000/api/v1/collaborate \
 
 ### 依赖替换实验
 
-`CollaborationOrchestrator` 构造器可接收角色实例。为一个角色写 test double，返回同样的类型化工件，证明 orchestrator 使用它。不要用任意 `dict` 绕开协议。
+`CollaborationOrchestrator` 构造器接收 retriever 和可选角色实例。编写 planner test double 改变 `Plan.retrieval_query`，再用 recording retriever 证明 researcher 检索的正是该值。不要用任意 `dict` 绕开协议。
 
 ### 诚实度量开销
 
@@ -89,9 +89,9 @@ curl --silent http://localhost:8000/api/v1/collaborate \
 
 选择 verifier、router、privacy reviewer 或 formatter，写一页说明：当前失败、输入/输出字段、它拥有的不变量、序列位置、阻断/重试、测试/评估、预计成本，以及在什么条件下拒绝加入。
 
-### 中级：删除仪式化角色
+### 中级：识别仪式化角色
 
-Planner 总是返回相同三项任务，且下游从不读取 `Plan`。论证应保留、改变还是删除，必须基于可观察行为。
+在不改变原始 HTTP 问题的前提下，临时修改 planner 的 `retrieval_query`。编写测试，确保 researcher 如果忽略 plan、仍检索原问题，测试就会失败。再说明什么证据能支持保留或删除 planner 边界。
 
 ### 高级：并行研究设计
 

--- a/course/translations/zh-CN/04-typed-orchestration/README.md
+++ b/course/translations/zh-CN/04-typed-orchestration/README.md
@@ -35,7 +35,7 @@ CollaborationResult
 
 | 工件 | 关键不变量 |
 | --- | --- |
-| `Plan` | 任务有序，query count 非负 |
+| `Plan` | retrieval query 已规范化，任务有序，query count 非负 |
 | `EvidenceBundle` | match 保留排序，来源只来自检索 |
 | `Critique` | 决定与覆盖率描述当前证据 |
 | `WrittenAnswer` | 阻断时引用为 0 |
@@ -63,7 +63,7 @@ TypeScript 编译类型无法校验任意网络 JSON，所以必须保留运行�
 .venv/bin/python - <<'PY'
 from dataclasses import FrozenInstanceError
 from app.collaboration import Plan
-plan = Plan(tasks=("retrieve",), query_term_count=1)
+plan = Plan(retrieval_query="agent planning", tasks=("retrieve",), query_term_count=2)
 try:
     plan.query_term_count = 99
 except FrozenInstanceError as error:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,8 @@
 
 ## Multi-agent learning path
 
-`POST /api/v1/collaborate` uses the same bounded Markdown retrieval layer and runs four local roles in a fixed order:
+`POST /api/v1/collaborate` injects the same bounded Markdown retriever used by the single-path API
+into the collaboration workflow and runs four local roles in a fixed order:
 
 ```mermaid
 sequenceDiagram
@@ -29,7 +30,12 @@ sequenceDiagram
   W-->>API: WrittenAnswer
 ```
 
-The role artifacts are frozen dataclasses. The orchestrator owns ordering and produces a server-controlled run ID plus four operational trace stages. A trace stage contains a role identifier, outcome, safe summary, and numeric/boolean metrics. It is an audit-friendly workflow record, not model chain-of-thought.
+The planner stores the normalized retrieval query in an immutable `Plan`. The researcher receives
+that exact plan and owns the retriever call that turns it into an `EvidenceBundle`; retrieval is not
+precomputed at the HTTP boundary. The remaining role artifacts are also frozen dataclasses. The
+orchestrator owns ordering and produces a server-controlled run ID plus four operational trace
+stages. A trace stage contains a role identifier, outcome, safe summary, and numeric/boolean
+metrics. It is an audit-friendly workflow record, not model chain-of-thought.
 
 The critic approves synthesis only when retrieval produced evidence. Without evidence it emits a blocked outcome and the writer returns a fixed insufficient-evidence response with zero citations. The default collaboration workflow never calls the optional external provider.
 

--- a/scripts/evaluate_collaboration.py
+++ b/scripts/evaluate_collaboration.py
@@ -59,11 +59,10 @@ def load_cases(path: Path) -> list[dict[str, Any]]:
 def evaluate(cases_path: Path, knowledge_dir: Path) -> list[EvaluationResult]:
     cases = load_cases(cases_path)
     knowledge = KnowledgeBase(str(knowledge_dir))
-    orchestrator = CollaborationOrchestrator()
+    orchestrator = CollaborationOrchestrator(retriever=knowledge)
     results: list[EvaluationResult] = []
     for case in cases:
-        matches = knowledge.search(case["question"])
-        run = orchestrator.run(question=case["question"], matches=matches)
+        run = orchestrator.run(question=case["question"])
         critic = next(stage for stage in run.trace if stage.agent == "critic")
         expected = case["expected_grounded"]
         results.append(


### PR DESCRIPTION
## Summary

- put the normalized retrieval query in the immutable `Plan`
- make the researcher receive that plan and own the injected retriever call
- route both HTTP collaboration and evaluation through the same executable handoff
- add a recording-retriever test proving planner output controls downstream retrieval
- align the architecture guide and English/Simplified Chinese lessons

## Verification

- `make lint`
- `make test` — backend 39 passed; frontend 22 passed
- `make docs` — 46 Markdown files, 16 maintained lesson pages
- `make evaluate` — 3/3 passed

Closes #60
