### PR TITLE
fix: disclose external provider data forwarding

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -108,6 +108,7 @@ async def profile(config: Settings = Depends(get_settings)) -> ProfileResponse:
         name=config.app_name,
         description=config.app_description,
         max_question_chars=config.max_question_chars,
+        external_provider_enabled=config.provider_state == "openai-compatible",
     )
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -74,3 +74,4 @@ class ProfileResponse(BaseModel):
     name: str
     description: str
     max_question_chars: int
+    external_provider_enabled: bool

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -43,7 +43,29 @@ async def test_profile_exposes_public_runtime_configuration(client: httpx.AsyncC
         "name": settings.app_name,
         "description": settings.app_description,
         "max_question_chars": settings.max_question_chars,
+        "external_provider_enabled": False,
     }
+
+
+@pytest.mark.anyio
+async def test_profile_discloses_external_provider_without_exposing_configuration(
+    client: httpx.AsyncClient,
+) -> None:
+    settings = get_settings()
+    originals = (settings.llm_base_url, settings.llm_api_key, settings.llm_model)
+    settings.llm_base_url = "https://private-provider.example/v1"
+    settings.llm_api_key = "private-api-key"
+    settings.llm_model = "private-model"
+    try:
+        response = await client.get("/api/v1/profile")
+    finally:
+        settings.llm_base_url, settings.llm_api_key, settings.llm_model = originals
+
+    assert response.status_code == 200
+    assert response.json()["external_provider_enabled"] is True
+    assert "private-provider" not in response.text
+    assert "private-api-key" not in response.text
+    assert "private-model" not in response.text
 
 
 @pytest.mark.anyio

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,7 +10,10 @@ Readiness and public document count. It returns HTTP `503` with `status: "not_re
 
 ## `GET /api/v1/profile`
 
-Returns the configured public agent name, description, and `max_question_chars` so the browser can enforce the same input limit.
+Returns the configured public agent name, description, and `max_question_chars` so the browser can
+enforce the same input limit. The safe boolean `external_provider_enabled` lets the browser disclose
+the question's data destination before submission. It never reveals the provider URL, model ID, or
+credentials.
 
 ## `POST /api/v1/chat`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,9 @@
 
 1. Browser questions are untrusted and validated by Pydantic.
 2. Knowledge files are operator-controlled but bounded by the configured root and file-size limit; symbolic links are rejected and content is rendered as plain text.
-3. Provider output is untrusted and rendered as text, never inserted as HTML.
+3. Provider output is untrusted and rendered as text, never inserted as HTML. Before submission,
+   the browser uses the public `external_provider_enabled` flag to disclose whether the question,
+   recent history, and retrieved context will be forwarded to the configured provider.
 4. Secrets are loaded from environment variables and excluded from source control.
 
 ## Request path

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -11,6 +11,7 @@ const profileResponse = {
     name: "My Answer Agent",
     description: "A grounded question-answering agent built from your documents.",
     max_question_chars: 8000,
+    external_provider_enabled: false,
   }),
 };
 
@@ -172,6 +173,7 @@ it("applies the configured public profile and question limit", async () => {
         name: "Documentation Helper",
         description: "Answers from reviewed documentation.",
         max_question_chars: 42,
+        external_provider_enabled: false,
       }),
     }),
   );
@@ -187,6 +189,48 @@ it("applies the configured public profile and question limit", async () => {
   );
   expect(screen.getByLabelText(/ask the example/i)).toHaveAttribute("maxlength", "42");
   expect(screen.getByText(/0 \/ 42 characters/)).toBeInTheDocument();
+});
+
+it("discloses external provider forwarding before question submission", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "Provider-backed Agent",
+        description: "Answers using a configured provider.",
+        max_question_chars: 8000,
+        external_provider_enabled: true,
+      }),
+    }),
+  );
+
+  render(<App />);
+
+  expect(
+    await screen.findByText(
+      "Questions, recent conversation history, and retrieved context are forwarded to the configured model provider.",
+    ),
+  ).toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole("radio", { name: "Multi-agent lab" }));
+  expect(
+    screen.getByText(
+      "Questions are processed by this deployment and are not sent to an external model provider.",
+    ),
+  ).toBeInTheDocument();
+});
+
+it("uses a conservative disclosure when profile metadata is unavailable", () => {
+  vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => undefined)));
+
+  render(<App />);
+
+  expect(
+    screen.getByText(
+      "External provider use is not confirmed. Questions may be forwarded to a configured provider.",
+    ),
+  ).toBeInTheDocument();
 });
 
 it("runs the multi-agent lab and renders its ordered operational trace", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,11 @@ export function App() {
   const [workflowMode, setWorkflowMode] = useState<WorkflowMode>("standard");
   const text = messages[locale];
   const maxQuestionChars = profile?.max_question_chars ?? DEFAULT_MAX_QUESTION_CHARS;
+  const privacyMessage = profile
+    ? profile.external_provider_enabled && workflowMode === "standard"
+      ? text.inputPrivacyProvider
+      : text.inputPrivacyLocal
+    : text.inputPrivacyUnconfirmed;
 
   useEffect(() => {
     persistLocale(locale);
@@ -163,7 +168,7 @@ export function App() {
           </button>
         </div>
         <div id="question-meta" className="question-meta">
-          <span>{text.inputPrivacy}</span>
+          <span>{privacyMessage}</span>
           <span>
             {question.length} / {maxQuestionChars} {text.characters}
           </span>

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -105,6 +105,7 @@ it("validates public profile metadata", async () => {
         name: "My Agent",
         description: "My description",
         max_question_chars: 1200,
+        external_provider_enabled: true,
       }),
     }),
   );
@@ -113,5 +114,22 @@ it("validates public profile metadata", async () => {
     name: "My Agent",
     description: "My description",
     max_question_chars: 1200,
+    external_provider_enabled: true,
   });
+});
+
+it("rejects a profile without an explicit provider disclosure flag", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "My Agent",
+        description: "My description",
+        max_question_chars: 1200,
+      }),
+    }),
+  );
+
+  await expect(loadProfile()).rejects.toMatchObject({ code: "invalid_profile" });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -19,7 +19,12 @@ export type CollaborationResponse = {
   sources: Source[];
   trace: CollaborationStage[];
 };
-export type ProfileResponse = { name: string; description: string; max_question_chars: number };
+export type ProfileResponse = {
+  name: string;
+  description: string;
+  max_question_chars: number;
+  external_provider_enabled: boolean;
+};
 
 export class ApiError extends Error {
   constructor(
@@ -79,7 +84,8 @@ function parseProfileResponse(value: unknown): ProfileResponse {
     typeof profile.description !== "string" ||
     typeof profile.max_question_chars !== "number" ||
     !Number.isInteger(profile.max_question_chars) ||
-    profile.max_question_chars < 1
+    profile.max_question_chars < 1 ||
+    typeof profile.external_provider_enabled !== "boolean"
   ) {
     throw new ApiError("Server returned an invalid profile.", 502, "invalid_profile");
   }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -24,7 +24,9 @@ type Messages = {
   answer: string;
   groundingSources: string;
   noSources: string;
-  inputPrivacy: string;
+  inputPrivacyUnconfirmed: string;
+  inputPrivacyLocal: string;
+  inputPrivacyProvider: string;
   characters: string;
   requestFailed: string;
   extractiveMode: string;
@@ -57,7 +59,12 @@ export const messages: Record<Locale, Messages> = {
     answer: "Answer",
     groundingSources: "Grounding sources",
     noSources: "No matching source excerpts were found.",
-    inputPrivacy: "Questions are sent only to this deployment.",
+    inputPrivacyUnconfirmed:
+      "External provider use is not confirmed. Questions may be forwarded to a configured provider.",
+    inputPrivacyLocal:
+      "Questions are processed by this deployment and are not sent to an external model provider.",
+    inputPrivacyProvider:
+      "Questions, recent conversation history, and retrieved context are forwarded to the configured model provider.",
     characters: "characters",
     requestFailed: "Request failed",
     extractiveMode: "extractive",
@@ -90,7 +97,9 @@ export const messages: Record<Locale, Messages> = {
     answer: "回答",
     groundingSources: "依据来源",
     noSources: "未找到匹配的来源片段。",
-    inputPrivacy: "问题只会发送到当前部署。",
+    inputPrivacyUnconfirmed: "尚未确认是否使用外部模型服务；问题可能会转发给已配置的服务。",
+    inputPrivacyLocal: "问题由当前部署处理，不会发送给外部模型服务。",
+    inputPrivacyProvider: "问题、近期对话历史和检索到的上下文会转发给当前配置的模型服务。",
     characters: "字符",
     requestFailed: "请求失败",
     extractiveMode: "本地抽取",
@@ -121,7 +130,9 @@ export const messages: Record<Locale, Messages> = {
     answer: "回答",
     groundingSources: "依據來源",
     noSources: "找不到相符的來源片段。",
-    inputPrivacy: "問題只會傳送到目前的部署。",
+    inputPrivacyUnconfirmed: "尚未確認是否使用外部模型服務；問題可能會轉送給已設定的服務。",
+    inputPrivacyLocal: "問題由目前部署處理，不會傳送給外部模型服務。",
+    inputPrivacyProvider: "問題、近期對話記錄和檢索到的內容會轉送給目前設定的模型服務。",
     characters: "字元",
     requestFailed: "請求失敗",
     extractiveMode: "本機擷取",
@@ -152,7 +163,12 @@ export const messages: Record<Locale, Messages> = {
     answer: "回答",
     groundingSources: "根拠となるソース",
     noSources: "一致するソース抜粋は見つかりませんでした。",
-    inputPrivacy: "質問はこのデプロイ先にのみ送信されます。",
+    inputPrivacyUnconfirmed:
+      "外部モデルプロバイダーの使用は未確認です。質問が設定済みプロバイダーに転送される場合があります。",
+    inputPrivacyLocal:
+      "質問はこのデプロイで処理され、外部モデルプロバイダーには送信されません。",
+    inputPrivacyProvider:
+      "質問、最近の会話履歴、取得したコンテキストは、設定済みのモデルプロバイダーに転送されます。",
     characters: "文字",
     requestFailed: "リクエストに失敗しました",
     extractiveMode: "ローカル抽出",
@@ -185,7 +201,11 @@ export const messages: Record<Locale, Messages> = {
     answer: "답변",
     groundingSources: "근거 출처",
     noSources: "일치하는 근거 출처를 찾지 못했습니다.",
-    inputPrivacy: "질문은 현재 배포 환경에만 전송됩니다.",
+    inputPrivacyUnconfirmed:
+      "외부 모델 공급자 사용 여부가 확인되지 않았습니다. 질문이 구성된 공급자에게 전달될 수 있습니다.",
+    inputPrivacyLocal: "질문은 이 배포 환경에서 처리되며 외부 모델 공급자에게 전송되지 않습니다.",
+    inputPrivacyProvider:
+      "질문, 최근 대화 기록 및 검색된 컨텍스트가 구성된 모델 공급자에게 전달됩니다.",
     characters: "자",
     requestFailed: "요청 실패",
     extractiveMode: "로컬 추출",
@@ -218,7 +238,12 @@ export const messages: Record<Locale, Messages> = {
     answer: "Respuesta",
     groundingSources: "Fuentes de respaldo",
     noSources: "No se encontraron fragmentos de fuentes coincidentes.",
-    inputPrivacy: "Las preguntas solo se envían a este despliegue.",
+    inputPrivacyUnconfirmed:
+      "No se ha confirmado el uso de un proveedor externo. Las preguntas pueden reenviarse a un proveedor configurado.",
+    inputPrivacyLocal:
+      "Las preguntas se procesan en este despliegue y no se envían a un proveedor de modelos externo.",
+    inputPrivacyProvider:
+      "Las preguntas, el historial reciente y el contexto recuperado se reenvían al proveedor de modelos configurado.",
     characters: "caracteres",
     requestFailed: "La solicitud ha fallado",
     extractiveMode: "extractivo local",
@@ -251,7 +276,12 @@ export const messages: Record<Locale, Messages> = {
     answer: "Réponse",
     groundingSources: "Sources de référence",
     noSources: "Aucun extrait de source correspondant n’a été trouvé.",
-    inputPrivacy: "Les questions sont envoyées uniquement à ce déploiement.",
+    inputPrivacyUnconfirmed:
+      "L’utilisation d’un fournisseur externe n’est pas confirmée. Les questions peuvent être transmises à un fournisseur configuré.",
+    inputPrivacyLocal:
+      "Les questions sont traitées par ce déploiement et ne sont pas envoyées à un fournisseur de modèle externe.",
+    inputPrivacyProvider:
+      "Les questions, l’historique récent et le contexte récupéré sont transmis au fournisseur de modèle configuré.",
     characters: "caractères",
     requestFailed: "Échec de la requête",
     extractiveMode: "extraction locale",
@@ -284,7 +314,12 @@ export const messages: Record<Locale, Messages> = {
     answer: "Antwort",
     groundingSources: "Belegquellen",
     noSources: "Es wurden keine passenden Quellenauszüge gefunden.",
-    inputPrivacy: "Fragen werden nur an diese Bereitstellung gesendet.",
+    inputPrivacyUnconfirmed:
+      "Die Nutzung eines externen Modellanbieters ist nicht bestätigt. Fragen können an einen konfigurierten Anbieter weitergeleitet werden.",
+    inputPrivacyLocal:
+      "Fragen werden in dieser Bereitstellung verarbeitet und nicht an einen externen Modellanbieter gesendet.",
+    inputPrivacyProvider:
+      "Fragen, der letzte Gesprächsverlauf und abgerufener Kontext werden an den konfigurierten Modellanbieter weitergeleitet.",
     characters: "Zeichen",
     requestFailed: "Anfrage fehlgeschlagen",
     extractiveMode: "lokale Extraktion",
@@ -317,7 +352,12 @@ export const messages: Record<Locale, Messages> = {
     answer: "Resposta",
     groundingSources: "Fontes de referência",
     noSources: "Nenhum trecho de fonte correspondente foi encontrado.",
-    inputPrivacy: "As perguntas são enviadas apenas para esta implantação.",
+    inputPrivacyUnconfirmed:
+      "O uso de provedor externo não foi confirmado. As perguntas podem ser encaminhadas a um provedor configurado.",
+    inputPrivacyLocal:
+      "As perguntas são processadas nesta implantação e não são enviadas a um provedor de modelo externo.",
+    inputPrivacyProvider:
+      "As perguntas, o histórico recente e o contexto recuperado são encaminhados ao provedor de modelo configurado.",
     characters: "caracteres",
     requestFailed: "Falha na solicitação",
     extractiveMode: "extração local",


### PR DESCRIPTION
## Summary

- expose only a safe `external_provider_enabled` boolean in the public profile
- show conservative copy before profile metadata is known
- distinguish local/collaboration processing from standard provider-mode forwarding
- disclose question, recent history, and retrieved-context forwarding in all nine UI locales
- validate the new field at the browser boundary without exposing provider configuration
- document the additive profile field and trust boundary

## Verification

- `make lint`
- `make test` — backend 40 passed; frontend 25 passed
- `make docs` — 46 Markdown files, 16 maintained lesson pages
- `make evaluate` — 3/3 passed

Closes #62
