### PR TITLE
perf: cache unchanged knowledge documents

### DIFF
--- a/backend/app/knowledge.py
+++ b/backend/app/knowledge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from threading import RLock
 
 _TOKEN = re.compile(r"[a-z0-9]+|[\u3400-\u9fff]", re.IGNORECASE)
 _ATX_HEADING = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)(?:\s+#+)?$")
@@ -69,6 +70,15 @@ class Match:
     score: float
 
 
+@dataclass(frozen=True)
+class _KnowledgeFile:
+    resolved: Path
+    relative_path: str
+    size: int
+    modified_ns: int
+    changed_ns: int
+
+
 def _tokens(value: str) -> set[str]:
     return {token.lower() for token in _TOKEN.findall(value)}
 
@@ -106,24 +116,18 @@ class KnowledgeBase:
     def __init__(self, directory: str, *, max_document_bytes: int = 1_000_000) -> None:
         self.directory = Path(directory)
         self.max_document_bytes = max_document_bytes
+        self._cache_lock = RLock()
+        self._cached_root: Path | None = None
+        self._cached_signature: tuple[tuple[str, int, int, int], ...] | None = None
+        self._cached_documents: tuple[Document, ...] = ()
 
-    def documents(self) -> list[Document]:
-        if not self.directory.exists():
-            return []
-
-        try:
-            root = self.directory.resolve(strict=True)
-        except OSError as error:
-            raise KnowledgeLoadError("knowledge_directory_unavailable") from error
-        if not root.is_dir():
-            raise KnowledgeLoadError("knowledge_directory_invalid")
-
-        result: list[Document] = []
+    def _files(self, root: Path) -> list[_KnowledgeFile]:
         try:
             paths = sorted(self.directory.rglob("*.md"))
         except OSError as error:
             raise KnowledgeLoadError("knowledge_directory_unavailable") from error
 
+        result: list[_KnowledgeFile] = []
         for path in paths:
             if path.is_symlink():
                 raise KnowledgeLoadError("knowledge_symlink_rejected")
@@ -135,9 +139,42 @@ class KnowledgeBase:
             if not resolved.is_file():
                 continue
             try:
-                if resolved.stat().st_size > self.max_document_bytes:
+                stat = resolved.stat()
+                if stat.st_size > self.max_document_bytes:
                     raise KnowledgeLoadError("knowledge_document_too_large")
-                text = resolved.read_text(encoding="utf-8")
+            except KnowledgeLoadError:
+                raise
+            except OSError as error:
+                raise KnowledgeLoadError("knowledge_document_unreadable") from error
+
+            result.append(
+                _KnowledgeFile(
+                    resolved=resolved,
+                    relative_path=path.relative_to(self.directory).as_posix(),
+                    size=stat.st_size,
+                    modified_ns=stat.st_mtime_ns,
+                    changed_ns=stat.st_ctime_ns,
+                )
+            )
+        return result
+
+    @staticmethod
+    def _signature(
+        files: list[_KnowledgeFile],
+    ) -> tuple[tuple[str, int, int, int], ...]:
+        return tuple(
+            (item.relative_path, item.size, item.modified_ns, item.changed_ns) for item in files
+        )
+
+    def _read(self, files: list[_KnowledgeFile]) -> list[Document]:
+        result: list[Document] = []
+        for item in files:
+            try:
+                with item.resolved.open("rb") as source:
+                    raw = source.read(self.max_document_bytes + 1)
+                if len(raw) > self.max_document_bytes:
+                    raise KnowledgeLoadError("knowledge_document_too_large")
+                text = raw.decode("utf-8")
             except KnowledgeLoadError:
                 raise
             except (OSError, UnicodeError) as error:
@@ -145,12 +182,47 @@ class KnowledgeBase:
 
             result.append(
                 Document(
-                    title=_title(path, text),
-                    path=path.relative_to(self.directory).as_posix(),
+                    title=_title(Path(item.relative_path), text),
+                    path=item.relative_path,
                     text=text,
                 )
             )
         return result
+
+    def documents(self) -> list[Document]:
+        if not self.directory.exists():
+            with self._cache_lock:
+                self._cached_root = None
+                self._cached_signature = None
+                self._cached_documents = ()
+            return []
+
+        try:
+            root = self.directory.resolve(strict=True)
+        except OSError as error:
+            raise KnowledgeLoadError("knowledge_directory_unavailable") from error
+        if not root.is_dir():
+            raise KnowledgeLoadError("knowledge_directory_invalid")
+
+        files = self._files(root)
+        signature = self._signature(files)
+        with self._cache_lock:
+            for _ in range(2):
+                if root == self._cached_root and signature == self._cached_signature:
+                    return list(self._cached_documents)
+
+                documents = self._read(files)
+                refreshed_files = self._files(root)
+                refreshed_signature = self._signature(refreshed_files)
+                if signature == refreshed_signature:
+                    self._cached_root = root
+                    self._cached_signature = signature
+                    self._cached_documents = tuple(documents)
+                    return list(self._cached_documents)
+                files = refreshed_files
+                signature = refreshed_signature
+
+        raise KnowledgeLoadError("knowledge_corpus_changed")
 
     def search(
         self,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,9 @@
+from functools import lru_cache
+
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 
 from .collaboration import CollaborationOrchestrator
 from .config import Settings, get_settings
@@ -49,6 +52,11 @@ class SemanticLimitError(Exception):
         self.detail = detail
 
 
+@lru_cache(maxsize=16)
+def _knowledge_base(directory: str, max_document_bytes: int) -> KnowledgeBase:
+    return KnowledgeBase(directory, max_document_bytes=max_document_bytes)
+
+
 @app.exception_handler(SemanticLimitError)
 async def semantic_limit_error(_: Request, error: SemanticLimitError) -> JSONResponse:
     return JSONResponse(
@@ -90,9 +98,8 @@ async def health() -> dict[str, str]:
 async def ready(
     config: Settings = Depends(get_settings),
 ) -> JSONResponse:
-    documents = KnowledgeBase(
-        config.knowledge_dir, max_document_bytes=config.max_document_bytes
-    ).documents()
+    knowledge = _knowledge_base(config.knowledge_dir, config.max_document_bytes)
+    documents = await run_in_threadpool(knowledge.documents)
     is_ready = bool(documents) and config.provider_state != "misconfigured"
     content: dict[str, object] = {
         "status": "ready" if is_ready else "not_ready",
@@ -124,9 +131,8 @@ async def chat(payload: ChatRequest, config: Settings = Depends(get_settings)) -
             code="history_too_large",
             detail="history exceeds configured limit",
         )
-    matches = KnowledgeBase(
-        config.knowledge_dir, max_document_bytes=config.max_document_bytes
-    ).search(payload.question)
+    knowledge = _knowledge_base(config.knowledge_dir, config.max_document_bytes)
+    matches = await run_in_threadpool(knowledge.search, payload.question)
     answer, mode = await generate_answer(
         question=payload.question,
         history=payload.history,
@@ -158,9 +164,11 @@ async def collaborate(
             code="question_too_large",
             detail="question exceeds configured limit",
         )
-    result = CollaborationOrchestrator(
-        retriever=KnowledgeBase(config.knowledge_dir, max_document_bytes=config.max_document_bytes)
-    ).run(question=payload.question)
+    knowledge = _knowledge_base(config.knowledge_dir, config.max_document_bytes)
+    result = await run_in_threadpool(
+        CollaborationOrchestrator(retriever=knowledge).run,
+        question=payload.question,
+    )
     return CollaborationResponse(
         run_id=result.run_id,
         workflow=result.workflow,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,8 +1,10 @@
+import threading
 from pathlib import Path
 
 import httpx
 import pytest
 
+import app.main as main_module
 from app.config import get_settings
 from app.main import app
 
@@ -155,6 +157,31 @@ async def test_multi_agent_collaboration_returns_typed_trace(
     ]
     assert "[profile.md]" in body["answer"]
     assert body["sources"][0]["path"] == "profile.md"
+
+
+@pytest.mark.anyio
+async def test_knowledge_search_runs_outside_the_async_event_loop(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_loop_thread = threading.get_ident()
+    search_threads: list[int] = []
+
+    class RecordingKnowledgeBase:
+        def search(self, question: str, *, limit: int = 4) -> list:
+            search_threads.append(threading.get_ident())
+            return []
+
+    knowledge = RecordingKnowledgeBase()
+    monkeypatch.setattr(main_module, "_knowledge_base", lambda *_: knowledge)
+
+    chat = await client.post("/api/v1/chat", json={"question": "Unknown fact?"})
+    collaboration = await client.post("/api/v1/collaborate", json={"question": "Unknown fact?"})
+
+    assert chat.status_code == 200
+    assert collaboration.status_code == 200
+    assert len(search_threads) == 2
+    assert all(thread != event_loop_thread for thread in search_threads)
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_knowledge.py
+++ b/backend/tests/test_knowledge.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -100,3 +101,40 @@ def test_search_minimum_score_is_inclusive_and_validated(tmp_path: Path) -> None
     assert knowledge.search("Alpha Python Rust", min_score=0.67) == []
     with pytest.raises(ValueError, match="min_score"):
         knowledge.search("Alpha", min_score=1.1)
+
+
+def test_documents_cache_is_reused_and_invalidated_by_corpus_changes(
+    tmp_path: Path,
+) -> None:
+    profile = tmp_path / "profile.md"
+    profile.write_text("# Profile\n\nFirst version.", encoding="utf-8")
+    knowledge = KnowledgeBase(str(tmp_path))
+
+    first = knowledge.documents()
+    second = knowledge.documents()
+
+    assert first is not second
+    assert first[0] is second[0]
+
+    profile.write_text("# Profile\n\nA longer second version.", encoding="utf-8")
+    changed = knowledge.documents()
+    assert changed[0].text.endswith("A longer second version.")
+    assert changed[0] is not first[0]
+
+    extra = tmp_path / "extra.md"
+    extra.write_text("# Extra\n\nAnother document.", encoding="utf-8")
+    assert [document.path for document in knowledge.documents()] == ["extra.md", "profile.md"]
+
+    profile.unlink()
+    assert [document.path for document in knowledge.documents()] == ["extra.md"]
+
+
+def test_concurrent_document_reads_publish_one_consistent_cache(tmp_path: Path) -> None:
+    (tmp_path / "profile.md").write_text("# Profile\n\nStable content.", encoding="utf-8")
+    knowledge = KnowledgeBase(str(tmp_path))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: knowledge.documents(), range(32)))
+
+    assert all([document.path for document in result] == ["profile.md"] for result in results)
+    assert len({id(result[0]) for result in results}) == 1

--- a/course/02-retrieval/README.md
+++ b/course/02-retrieval/README.md
@@ -61,6 +61,16 @@ A deterministic lexical retriever is useful for teaching because:
 
 Its simplicity is not a claim of state-of-the-art quality.
 
+## Runtime I/O and cache boundary
+
+The API reuses immutable parsed `Document` values only while a filesystem signature is unchanged.
+It still scans metadata and repeats the root, symlink, file-type, and size checks on every access;
+adding, editing, or removing a Markdown file invalidates the cached corpus. API routes run the
+synchronous scan/search in a worker thread so it does not block FastAPI's async event loop.
+
+This is a process-local performance cache, not storage or a source of truth. A restart begins with
+an empty cache, and the configured filesystem remains authoritative.
+
 ## Read the implementation
 
 Open [`backend/app/knowledge.py`](../../backend/app/knowledge.py) and follow:

--- a/course/translations/zh-CN/02-retrieval/README.md
+++ b/course/translations/zh-CN/02-retrieval/README.md
@@ -38,6 +38,14 @@ Agent-Me 使用一个刻意简单的词法基线：
 
 简单基线的价值在于分数可解释、无外部服务、测试快速稳定，后续改进也有对照；它不是先进检索质量声明。
 
+## 运行时 I/O 与缓存边界
+
+只有文件系统签名不变时，API 才会复用不可变的 `Document` 解析结果。每次访问仍会扫描元数据，
+并重新执行根目录、symlink、文件类型和大小检查；新增、修改或删除 Markdown 都会让缓存失效。
+API route 会在线程池运行同步扫描与检索，避免阻塞 FastAPI 的 async event loop。
+
+这是进程内性能缓存，不是存储或事实来源。进程重启后缓存为空，配置的文件系统始终是权威来源。
+
 ## 阅读实现
 
 打开 [`backend/app/knowledge.py`](../../../../backend/app/knowledge.py)，依次读 `_TOKEN`、`_tokens`、`_content_chunks`、`documents`、`search` 和数据类；再阅读

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,13 @@ and returns up to four sources that meet the default `0.75` threshold. If all pr
 present, the service calls the provider's `/chat/completions` route using a grounded system message.
 Otherwise it returns the highest-ranked excerpt.
 
+The API reuses `KnowledgeBase` instances for identical roots and size limits. Every access still
+rescans bounded file metadata and re-enforces the root, symlink, file-type, and size rules; unchanged
+signatures reuse immutable parsed documents, while add/edit/remove operations invalidate the cache.
+Readiness, search, and the local collaboration run execute through Starlette's worker thread pool so
+synchronous filesystem work does not block the async event loop. The cache is process-local only;
+the filesystem remains authoritative after edits and process restarts.
+
 ## Multi-agent learning path
 
 `POST /api/v1/collaborate` injects the same bounded Markdown retriever used by the single-path API


### PR DESCRIPTION
## Summary

- reuse a bounded set of `KnowledgeBase` instances for identical configuration
- cache immutable parsed documents behind root + ordered path/size/mtime/ctime signatures
- repeat root, symlink, file-type, size, and bounded-read checks before publishing or reusing cache state
- invalidate on add, edit, removal, root change, or process restart
- serialize cache publication with a per-instance lock while allowing callers to receive independent list copies
- execute readiness, search, and local collaboration filesystem work through Starlette's worker thread pool
- document the process-local cache/source-of-truth boundary in English and Simplified Chinese

## Verification

- backend 46 passed, including cache reuse, add/edit/remove invalidation, 32 concurrent reads, and event-loop thread isolation for both chat paths
- frontend 25 passed
- `make lint`
- `make docs` — 46 Markdown files, 16 maintained lesson pages
- `make evaluate` — 4/4 passed

Closes #69
