### PR TITLE
security: add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "23 5 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}-${{ matrix.language }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
   security-events: write
 
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.ref }}-${{ matrix.language }}
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,14 @@ Do not send real credentials or private user data in a report. Maintainers will 
 ## Operator responsibilities
 
 This framework cannot make private documents safe to publish. Operators must review knowledge content, configure rate limiting and TLS, protect provider credentials, and publish an accurate privacy notice for their deployment.
+
+## Automated checks
+
+Pull requests and `main` run the normal lint/test/container workflow plus CodeQL
+`security-extended` analysis for Python and JavaScript/TypeScript. CodeQL also runs weekly so new
+queries can inspect unchanged code. Dependabot monitors Python, npm, GitHub Actions, and container
+dependencies; secret scanning is enabled on the public repository.
+
+These checks complement review, locked dependency audits, threat modeling, and deployment controls.
+A green scan does not prove that knowledge content is publishable or that an operator's ingress,
+rate limits, credentials, and privacy notice are correctly configured.


### PR DESCRIPTION
## Summary

- add separate Python and JavaScript/TypeScript CodeQL analyses
- run on pull requests, main pushes, and a weekly schedule
- use interpreted-language `none` builds with `security-extended` queries
- pin CodeQL Action v4.37.9 by commit SHA
- grant only source/action/package reads and security-result upload permission
- document the scan's role and explicit limitations in the security policy

## Verification

- workflow YAML parses successfully
- local full gate passes: backend 46, frontend 25, docs 46/16, evaluation 4/4
- the new PR CodeQL jobs must upload both language analyses successfully before merge

Closes #71
