### PR TITLE
community: allow blank issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Course and setup Q&A / 课程与环境提问
     url: https://github.com/jzjzzzzzzz/agent-me/discussions/categories/q-a


### PR DESCRIPTION
## Summary
- enable the blank issue option on the new issue page
- keep bug/feature templates and private security reporting links available

This makes it possible for contributors to open issues that do not fit an existing form.