### PR TITLE
fix(web): make the container frontend use a same-origin API gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@ API_BIND=127.0.0.1
 API_PORT=8000
 WEB_BIND=127.0.0.1
 WEB_PORT=5173
-VITE_API_BASE_URL=http://localhost:8000
+# Leave blank for the same-origin Vite/Nginx proxy. Set an origin only when the
+# browser must call an independently hosted API.
+VITE_API_BASE_URL=
 
 APP_NAME=My Answer Agent
 APP_DESCRIPTION=A grounded question-answering agent built from your own documents.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,12 @@ jobs:
             --data '{"question":"How does the example agent plan a project?"}' \
             | python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["grounded"] and len(data["trace"]) == 4'
           curl --fail --silent --show-error http://127.0.0.1:5173/ >/dev/null
+          curl --fail --silent --show-error http://127.0.0.1:5173/api/v1/collaborate \
+            --header 'Content-Type: application/json' \
+            --data '{"question":"How does the example agent plan a project?"}' \
+            | python3 -c 'import json,sys; data=json.load(sys.stdin); assert data["grounded"] and len(data["trace"]) == 4'
+          curl --fail --silent --show-error --head http://127.0.0.1:5173/ \
+            | grep --ignore-case '^x-content-type-options: nosniff'
       - name: Show logs after failure
         if: failure()
         run: docker compose logs --no-color

--- a/README.md
+++ b/README.md
@@ -139,11 +139,14 @@ docker compose up --build
 Open:
 
 - Web application: <http://localhost:5173>
+- Browser API gateway: <http://localhost:5173/api/v1/profile>
 - Interactive API docs: <http://localhost:8000/docs>
 - Health: <http://localhost:8000/health>
 - Readiness: <http://localhost:8000/ready>
 
 Local extractive and multi-agent lab modes require no API key.
+The browser uses the web container's same-origin `/api` gateway by default, so the Compose path
+does not depend on a browser-visible backend hostname or cross-origin requests.
 
 ### Option B — Local toolchain
 

--- a/course/00-course-setup/README.md
+++ b/course/00-course-setup/README.md
@@ -255,8 +255,9 @@ lock means `backend/pyproject.toml` changed without a reviewed `make lock` updat
 
 ### Frontend cannot reach the API
 
-Check `VITE_API_BASE_URL`, published ports, CORS origins, and `/health`. The default browser-facing API
-is `http://localhost:8000`.
+First open `http://localhost:5173/api/v1/profile`. The default Vite and Compose paths proxy
+same-origin `/api` requests to the backend. If you intentionally set `VITE_API_BASE_URL`, verify
+that origin, the published API port, `CORS_ORIGINS`, and `/health`.
 
 ### Readiness reports zero documents
 

--- a/course/translations/zh-CN/00-course-setup/README.md
+++ b/course/translations/zh-CN/00-course-setup/README.md
@@ -183,7 +183,9 @@ COLLABORATION_EVAL 4/4 passed
 ## 常见问题
 
 - **找不到 uv 或 lock 已过期：**安装 uv 0.11.x/0.12.x，并运行 `uv lock --project backend --check`。若 manifest 有意变更，运行 `make lock` 并审查完整 lock diff；不要绕过 `--locked`。
-- **前端连不上 API：**检查 `VITE_API_BASE_URL`、端口、CORS 和 `/health`。
+- **前端连不上 API：**先打开 `http://localhost:5173/api/v1/profile`。默认的 Vite 与 Compose
+  配置会把同源 `/api` 请求代理到后端；只有主动设置 `VITE_API_BASE_URL` 时才需要继续检查
+  独立 API 地址、端口、`CORS_ORIGINS` 和 `/health`。
 - **Ready 显示 0 文档：**检查 `KNOWLEDGE_DIR` 和 UTF-8 Markdown 文件。
 - **端口占用：**在 `.env` 修改 `API_PORT`/`WEB_PORT`，先运行 `docker compose config`。
 

--- a/course/translations/zh-TW/00-course-setup/README.md
+++ b/course/translations/zh-TW/00-course-setup/README.md
@@ -254,8 +254,9 @@ COLLABORATION_EVAL 4/4 passed
 
 ### 前端無法連上 API
 
-檢查 `VITE_API_BASE_URL`、對外連接埠、CORS 來源與 `/health`。預設提供給瀏覽器使用的 API
-為 `http://localhost:8000`。
+先開啟 `http://localhost:5173/api/v1/profile`。預設 Vite 與 Compose 設定會將同源 `/api`
+請求代理到後端；只有主動設定 `VITE_API_BASE_URL` 時，才需要繼續檢查獨立 API 位址、連接埠、
+`CORS_ORIGINS` 與 `/health`。
 
 ### Readiness 顯示零份文件
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     build:
       context: ./frontend
       args:
-        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:8000}
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
     ports:
       - "${WEB_BIND:-127.0.0.1}:${WEB_PORT:-5173}:80"
     depends_on:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,6 +10,13 @@
 
 The included Compose file is intended for local evaluation. It binds both services to loopback, runs the API with all Linux capabilities dropped, runs both services with read-only root filesystems and `no-new-privileges`, and gives Nginx only the capabilities and temporary filesystems it needs. Set `API_BIND` or `WEB_BIND` only when you intentionally need a non-loopback development listener.
 
+The web image sends browser requests to same-origin `/api` by default. Its Nginx configuration
+proxies that path to the Compose service `api:8000`, avoiding browser-visible internal hostnames and
+cross-origin configuration for the normal stack. If web and API are deployed into different
+networks, either provide an equivalent ingress route or set `VITE_API_BASE_URL` at image build time
+and configure an exact matching `CORS_ORIGINS` value. Do not set `VITE_API_BASE_URL=/api`; it is an
+origin prefix and would duplicate the API path.
+
 Production deployments must keep the application behind a TLS ingress; do not expose the API container directly.  Production deployments should use a managed ingress, runtime secret injection, immutable images, and automated backups for any persistence you add.
 
 ## Refresh locked Python dependencies

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,10 +3,11 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
-ARG VITE_API_BASE_URL=/api
+ARG VITE_API_BASE_URL=
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build
 FROM nginx:1.31-alpine@sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY security-headers.conf /etc/nginx/agent-me-security-headers.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,26 +6,33 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Permitted-Cross-Domain-Policies "none" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    include /etc/nginx/agent-me-security-headers.conf;
 
-    client_max_body_size 16k;
+    client_max_body_size 256k;
+
+    location /api/ {
+        proxy_pass http://api:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        limit_except GET POST OPTIONS { deny all; }
+    }
 
     location /assets/ {
         try_files $uri =404;
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # add_header does not inherit from the server block once this location
+        # defines Cache-Control, so include the security policy again.
+        include /etc/nginx/agent-me-security-headers.conf;
         limit_except GET { deny all; }
     }
 
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache";
+        include /etc/nginx/agent-me-security-headers.conf;
         limit_except GET { deny all; }
     }
 

--- a/frontend/security-headers.conf
+++ b/frontend/security-headers.conf
@@ -1,0 +1,7 @@
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Permitted-Cross-Domain-Policies "none" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -4,19 +4,21 @@ import { ApiError, ask, collaborate, loadProfile } from "./api";
 afterEach(() => vi.unstubAllGlobals());
 
 it("returns a typed grounded response", async () => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ answer: "Grounded", mode: "extractive", sources: [] }),
-    }),
-  );
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ answer: "Grounded", mode: "extractive", sources: [] }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
 
   await expect(ask("Question")).resolves.toEqual({
     answer: "Grounded",
     mode: "extractive",
     sources: [],
   });
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/v1/chat",
+    expect.objectContaining({ method: "POST" }),
+  );
 });
 
 it("uses a safe structured server error", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -37,7 +37,10 @@ export class ApiError extends Error {
   }
 }
 
-const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000").replace(/\/$/, "");
+// Use same-origin API requests by default. The development and container web
+// servers proxy /api to the backend, while deployments can still opt into an
+// explicit cross-origin API with VITE_API_BASE_URL.
+const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? "").trim().replace(/\/+$/, "");
 
 function isSource(value: unknown): value is Source {
   if (!value || typeof value !== "object") return false;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-export default defineConfig({ plugins: [react()] });
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: false,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Problem

The frontend image defaulted VITE_API_BASE_URL to /api, while the client already appends /api/v1. A default image build therefore requested /api/api/v1, and Nginx had no API proxy. In addition, location-level Cache-Control headers prevented the server-level security headers from being inherited by HTML and asset responses.

## Changes

- make browser API requests same-origin by default
- proxy /api through both Vite development server and container Nginx
- keep explicit cross-origin deployments available through VITE_API_BASE_URL
- preserve security headers on HTML and immutable asset locations
- align the gateway body limit with the application limit
- add frontend and container CI coverage for the actual gateway path
- document Compose and split-network deployment behavior in English, Simplified Chinese, and Traditional Chinese

## Verification

- npm run lint
- npm run typecheck
- npm test — 25 passed
- npm run build
- python3 scripts/check_docs.py
- ruff check / ruff format --check
- pytest -q backend/tests — 46 passed
- collaboration evaluation — 4/4 passed
- Nginx syntax test against the existing container image
- real isolated-container gateway smoke test: profile, collaboration, HTML headers, asset headers (SAME_ORIGIN_GATEWAY_PASS)

A full fresh Compose rebuild was also attempted locally; Docker Hub token retrieval timed out before image download, so GitHub container CI remains the clean pinned-image build verification.