### PR TITLE
feat: add a verified multi-agent workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: .venv/bin/ruff format --check backend scripts
       - run: .venv/bin/pytest backend/tests
       - run: .venv/bin/python scripts/evaluate_collaboration.py --json
+      - run: .venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json
 
   frontend:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -39,17 +39,22 @@ with a portfolio-ready capstone. No paid model API is required for the core cour
 
 ## What you will build
 
-You will evolve a small grounded Q&A service into a four-role collaboration workflow:
+You will evolve a small grounded Q&A service into a typed collaboration workflow with an optional
+post-write verification gate:
 
 ```text
 question
    │
    ▼
-planner ──Plan──▶ researcher ──EvidenceBundle──▶ critic ──Critique──▶ writer
+planner ──Plan──▶ researcher ──EvidenceBundle──▶ critic ──Critique──▶ writer ──▶ verifier
                        │                            │                     │
                        ▼                            └── block             ▼
-                Markdown knowledge                           answer + sources + trace
+                Markdown knowledge                    verified answer + sources + trace
 ```
+
+The baseline mode ends at the writer for a stable four-stage teaching contract. **Verified
+multi-agent** adds the fifth stage, checks citation-path and count invariants, and blocks a candidate
+answer when those checks fail.
 
 The repository is both **course material** and the **working reference implementation**. You do
 not study pseudocode and then discover that the real project is different: every lesson points to
@@ -60,6 +65,7 @@ By completing the course, you will be able to:
 - explain retrieval-grounded generation and its failure modes;
 - decide when role decomposition helps—and when one function is better;
 - design immutable, typed handoffs between planner, researcher, critic, and writer roles;
+- add a backward-compatible verifier policy and fail closed when output invariants break;
 - expose operational traces without exposing hidden chain-of-thought;
 - build deterministic behavioral evaluations for grounded and unsupported questions;
 - validate the same API contract in Python and TypeScript;
@@ -111,17 +117,19 @@ flowchart LR
   R --> Search
   R --> C[Critic]
   C --> W[Writer]
+  W -. verified policy .-> V[Verifier]
   Search --> Docs[(Markdown knowledge)]
   Chat -. optional .-> Provider[OpenAI-compatible provider]
-  Flow --> Trace[Answer + sources + safe trace]
+  V --> Trace[Verified answer + sources + safe trace]
+  W --> Trace
   Cases[(Versioned cases)] --> Eval[Evaluator]
   Eval --> CI[GitHub Actions]
 ```
 
-The default collaboration workflow is deterministic, sequential, and runs in one process. It is
-accurately described as **role-based multi-agent orchestration**. It does not claim to use four
-models, four autonomous processes, or a distributed worker platform. Lesson 07 explains what
-those stronger claims would require.
+Both collaboration policies are deterministic, sequential, and run in one process. They are
+accurately described as **role-based multi-agent orchestration with typed policy gates**. They do
+not claim to use five models, autonomous processes, formal truth verification, or a distributed
+worker platform. Lesson 07 explains what those stronger claims would require.
 
 ## Run the project
 

--- a/backend/app/collaboration.py
+++ b/backend/app/collaboration.py
@@ -7,12 +7,17 @@ from uuid import uuid4
 
 from .knowledge import Match
 
-AgentName: TypeAlias = Literal["planner", "researcher", "critic", "writer"]
+AgentName: TypeAlias = Literal["planner", "researcher", "critic", "writer", "verifier"]
 StageOutcome: TypeAlias = Literal["completed", "blocked"]
 MetricValue: TypeAlias = bool | int | float
+WorkflowName: TypeAlias = Literal[
+    "planner-researcher-critic-writer",
+    "planner-researcher-critic-writer-verifier",
+]
 
 _TOKEN = re.compile(r"[a-z0-9]+|[\u3400-\u9fff]", re.IGNORECASE)
 _INSUFFICIENT_EVIDENCE = "I could not find a grounded answer in the configured knowledge files."
+_VERIFICATION_FAILED = "I could not return a verified answer from the configured knowledge files."
 
 
 def _tokens(value: str) -> set[str]:
@@ -44,6 +49,14 @@ class WrittenAnswer:
 
 
 @dataclass(frozen=True)
+class Verification:
+    approved: bool
+    citation_paths_valid: bool
+    expected_citation_count: int
+    reported_citation_count: int
+
+
+@dataclass(frozen=True)
 class StageTrace:
     sequence: int
     agent: AgentName
@@ -55,7 +68,7 @@ class StageTrace:
 @dataclass(frozen=True)
 class CollaborationResult:
     run_id: str
-    workflow: str
+    workflow: WorkflowName
     answer: str
     grounded: bool
     matches: tuple[Match, ...]
@@ -122,6 +135,37 @@ class WriterAgent:
         )
 
 
+class VerifierAgent:
+    """Checks public answer invariants without exposing hidden reasoning."""
+
+    name: AgentName = "verifier"
+
+    def run(
+        self,
+        evidence: EvidenceBundle,
+        critique: Critique,
+        written: WrittenAnswer,
+    ) -> Verification:
+        paths = tuple(dict.fromkeys(match.document.path for match in evidence.matches))
+        expected_count = len(paths) if critique.grounded else 0
+        citation_paths_valid = (
+            all(f"[{path}]" in written.content for path in paths)
+            if critique.grounded
+            else written.content == _INSUFFICIENT_EVIDENCE
+        )
+        approved = (
+            written.citation_count == expected_count
+            and citation_paths_valid
+            and bool(written.content.strip())
+        )
+        return Verification(
+            approved=approved,
+            citation_paths_valid=citation_paths_valid,
+            expected_citation_count=expected_count,
+            reported_citation_count=written.citation_count,
+        )
+
+
 class CollaborationOrchestrator:
     """Runs explicit role handoffs and returns auditable operational artifacts.
 
@@ -129,7 +173,8 @@ class CollaborationOrchestrator:
     not model chain-of-thought or hidden reasoning.
     """
 
-    workflow = "planner-researcher-critic-writer"
+    baseline_workflow: WorkflowName = "planner-researcher-critic-writer"
+    verified_workflow: WorkflowName = "planner-researcher-critic-writer-verifier"
 
     def __init__(
         self,
@@ -139,20 +184,22 @@ class CollaborationOrchestrator:
         researcher: ResearcherAgent | None = None,
         critic: CriticAgent | None = None,
         writer: WriterAgent | None = None,
+        verifier: VerifierAgent | None = None,
     ) -> None:
         self.planner = planner or PlannerAgent()
         self.researcher = researcher or ResearcherAgent(retriever)
         self.critic = critic or CriticAgent()
         self.writer = writer or WriterAgent()
+        self.verifier = verifier or VerifierAgent()
 
-    def run(self, *, question: str) -> CollaborationResult:
+    def run(self, *, question: str, verify: bool = False) -> CollaborationResult:
         plan = self.planner.run(question)
         evidence = self.researcher.run(plan)
         critique = self.critic.run(question, evidence)
         written = self.writer.run(evidence, critique)
 
         document_count = len({match.document.path for match in evidence.matches})
-        trace = (
+        trace: tuple[StageTrace, ...] = (
             StageTrace(
                 sequence=1,
                 agent=self.planner.name,
@@ -202,11 +249,34 @@ class CollaborationOrchestrator:
                 },
             ),
         )
+        verification: Verification | None = None
+        if verify:
+            verification = self.verifier.run(evidence, critique, written)
+            trace += (
+                StageTrace(
+                    sequence=5,
+                    agent=self.verifier.name,
+                    outcome="completed" if verification.approved else "blocked",
+                    summary=(
+                        "Verified citation paths and answer metadata."
+                        if verification.approved
+                        else "Blocked the answer because verification invariants failed."
+                    ),
+                    metrics={
+                        "approved": verification.approved,
+                        "citation_paths_valid": verification.citation_paths_valid,
+                        "expected_citation_count": verification.expected_citation_count,
+                        "reported_citation_count": verification.reported_citation_count,
+                    },
+                ),
+            )
+
+        verification_approved = verification is None or verification.approved
         return CollaborationResult(
             run_id=f"run_{uuid4().hex}",
-            workflow=self.workflow,
-            answer=written.content,
-            grounded=critique.grounded,
+            workflow=self.verified_workflow if verify else self.baseline_workflow,
+            answer=written.content if verification_approved else _VERIFICATION_FAILED,
+            grounded=critique.grounded and verification_approved,
             matches=evidence.matches,
             trace=trace,
         )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -168,6 +168,7 @@ async def collaborate(
     result = await run_in_threadpool(
         CollaborationOrchestrator(retriever=knowledge).run,
         question=payload.question,
+        verify=payload.workflow == "verified",
     )
     return CollaborationResponse(
         run_id=result.run_id,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -29,6 +29,7 @@ class CollaborationRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     question: str = Field(min_length=1)
+    workflow: Literal["baseline", "verified"] = "baseline"
 
     @field_validator("question")
     @classmethod
@@ -54,7 +55,7 @@ class ChatResponse(BaseModel):
 
 class CollaborationStage(BaseModel):
     sequence: int = Field(ge=1)
-    agent: Literal["planner", "researcher", "critic", "writer"]
+    agent: Literal["planner", "researcher", "critic", "writer", "verifier"]
     outcome: Literal["completed", "blocked"]
     summary: str
     metrics: dict[str, bool | int | float]
@@ -62,7 +63,10 @@ class CollaborationStage(BaseModel):
 
 class CollaborationResponse(BaseModel):
     run_id: str = Field(pattern=r"^run_[0-9a-f]{32}$")
-    workflow: Literal["planner-researcher-critic-writer"]
+    workflow: Literal[
+        "planner-researcher-critic-writer",
+        "planner-researcher-critic-writer-verifier",
+    ]
     mode: Literal["multi-agent-local"] = "multi-agent-local"
     answer: str
     grounded: bool

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -160,6 +160,40 @@ async def test_multi_agent_collaboration_returns_typed_trace(
 
 
 @pytest.mark.anyio
+async def test_verified_collaboration_returns_a_five_stage_trace(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.post(
+        "/api/v1/collaborate",
+        json={"question": "prefers Python tools?", "workflow": "verified"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["workflow"] == "planner-researcher-critic-writer-verifier"
+    assert [stage["agent"] for stage in body["trace"]] == [
+        "planner",
+        "researcher",
+        "critic",
+        "writer",
+        "verifier",
+    ]
+    assert body["trace"][-1]["metrics"]["approved"] is True
+
+
+@pytest.mark.anyio
+async def test_collaboration_rejects_an_unknown_workflow(
+    client: httpx.AsyncClient,
+) -> None:
+    response = await client.post(
+        "/api/v1/collaborate",
+        json={"question": "prefers Python tools?", "workflow": "attacker-controlled"},
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
 async def test_knowledge_search_runs_outside_the_async_event_loop(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_collaboration.py
+++ b/backend/tests/test_collaboration.py
@@ -1,4 +1,10 @@
-from app.collaboration import CollaborationOrchestrator, Plan, PlannerAgent
+from app.collaboration import (
+    CollaborationOrchestrator,
+    Plan,
+    PlannerAgent,
+    WriterAgent,
+    WrittenAnswer,
+)
 from app.knowledge import Document, Match
 
 
@@ -27,6 +33,11 @@ class RewritingPlanner(PlannerAgent):
             tasks=("Retrieve evidence for the rewritten query.",),
             query_term_count=3,
         )
+
+
+class UnsupportedWriter(WriterAgent):
+    def run(self, evidence, critique) -> WrittenAnswer:
+        return WrittenAnswer(content="An unsupported answer.", citation_count=0)
 
 
 def test_role_handoffs_are_ordered_and_grounded() -> None:
@@ -80,3 +91,55 @@ def test_planner_output_controls_the_researcher_query() -> None:
 
     assert retriever.queries == ["rewritten retrieval query"]
     assert result.trace[0].metrics == {"task_count": 1, "query_term_count": 3}
+
+
+def test_verified_workflow_appends_a_typed_verifier_stage() -> None:
+    result = CollaborationOrchestrator(retriever=StubRetriever([match()])).run(
+        question="How does the agent plan from user goals?",
+        verify=True,
+    )
+
+    assert result.workflow == "planner-researcher-critic-writer-verifier"
+    assert result.grounded is True
+    assert [stage.agent for stage in result.trace] == [
+        "planner",
+        "researcher",
+        "critic",
+        "writer",
+        "verifier",
+    ]
+    assert result.trace[-1].outcome == "completed"
+    assert result.trace[-1].metrics == {
+        "approved": True,
+        "citation_paths_valid": True,
+        "expected_citation_count": 1,
+        "reported_citation_count": 1,
+    }
+
+
+def test_verified_workflow_blocks_an_answer_that_loses_its_citation() -> None:
+    result = CollaborationOrchestrator(
+        retriever=StubRetriever([match()]),
+        writer=UnsupportedWriter(),
+    ).run(question="How does the agent plan from user goals?", verify=True)
+
+    assert result.workflow == "planner-researcher-critic-writer-verifier"
+    assert result.grounded is False
+    assert result.answer == (
+        "I could not return a verified answer from the configured knowledge files."
+    )
+    assert result.trace[-1].agent == "verifier"
+    assert result.trace[-1].outcome == "blocked"
+    assert result.trace[-1].metrics["approved"] is False
+
+
+def test_verified_workflow_approves_the_safe_insufficient_evidence_response() -> None:
+    result = CollaborationOrchestrator(retriever=StubRetriever([])).run(
+        question="Unknown fact?",
+        verify=True,
+    )
+
+    assert result.grounded is False
+    assert result.trace[2].outcome == "blocked"
+    assert result.trace[-1].outcome == "completed"
+    assert result.trace[-1].metrics["expected_citation_count"] == 0

--- a/course/04-typed-orchestration/README.md
+++ b/course/04-typed-orchestration/README.md
@@ -188,7 +188,10 @@ evaluation, diagram, and docs. Do not use an arbitrary dictionary handoff.
 
 ### Advanced — version a public workflow
 
-Design how a client can distinguish the four-stage response from a future five-stage response.
+Compare the implemented `baseline` and `verified` policies. Explain how the workflow discriminator
+lets a client select the expected four- or five-stage contract before validating agent order.
+Add a parser test that gives the verified workflow identifier a four-stage trace and confirms it is
+rejected.
 Compare a new endpoint, workflow discriminator, and media/API version. Explain your compatibility
 choice.
 

--- a/course/05-critic-observability/README.md
+++ b/course/05-critic-observability/README.md
@@ -22,6 +22,7 @@ By the end, you can:
 - distinguish policy decisions from answer writing;
 - define safe operational trace content;
 - observe approved and blocked flows in the browser and API;
+- compare pre-write evidence policy with post-write contract verification;
 - test response parsing against malformed or unsafe trace shapes;
 - propose stronger evidence checks without promising impossible guarantees.
 
@@ -54,6 +55,32 @@ A stronger critic might evaluate:
 
 Every added check needs false-positive/false-negative evaluation and a defined failure behavior.
 
+## Critic and verifier are different gates
+
+The UI now exposes two collaboration policies:
+
+| Policy | Stages | Purpose |
+| --- | --- | --- |
+| `baseline` | planner → researcher → critic → writer | stable four-stage teaching contract |
+| `verified` | planner → researcher → critic → writer → verifier | add post-write invariant checks |
+
+The critic decides whether the available evidence permits writing. The verifier runs **after** the
+writer and checks the candidate artifact against mechanical rules:
+
+```text
+expected citation count == writer-reported citation count
+every unique evidence path appears as [path] in the answer
+safe insufficient-evidence output has zero citations
+```
+
+If a rule fails, the verifier does not repair or return the candidate. It marks its stage blocked,
+changes `grounded` to false, and substitutes a fixed server-controlled failure message. This is a
+fail-closed output gate and a testable state transition.
+
+These checks catch broken handoffs, citation loss, and incompatible writers. They do **not** prove
+that a sentence is entailed by a source, that sources are correct, or that the corpus is complete.
+Calling the feature “truth verification” would overstate what the implementation demonstrates.
+
 ## Safe trace versus chain-of-thought
 
 | Safe operational trace | Do not expose as a trace |
@@ -71,7 +98,7 @@ chain-of-thought, but the same trace discipline keeps future provider integratio
 
 ## Read the implementation
 
-1. `CriticAgent` and trace construction in [`collaboration.py`](../../backend/app/collaboration.py)
+1. `CriticAgent`, `VerifierAgent`, and trace construction in [`collaboration.py`](../../backend/app/collaboration.py)
 2. public trace schema in [`schemas.py`](../../backend/app/schemas.py)
 3. browser runtime validation in [`api.ts`](../../frontend/src/api.ts)
 4. trace rendering in [`App.tsx`](../../frontend/src/App.tsx)
@@ -128,7 +155,31 @@ A blocked critic is a successful policy outcome, not a crashed request.
 Use browser developer tools or curl. Confirm trace summaries are fixed operational statements and
 metrics contain only finite numbers or booleans.
 
-### Step 5 — prove the browser rejects malformed traces
+### Step 5 — verified output path
+
+Select **Verified multi-agent** and repeat the grounded question. Confirm:
+
+- the workflow identifier ends in `-verifier`;
+- the trace contains five ordered stages;
+- verifier metrics report `approved`, `citation_paths_valid`, expected citations, and reported
+  citations;
+- the answer and source list remain plain text.
+
+Then call the API directly:
+
+```bash
+curl --silent http://localhost:8000/api/v1/collaborate \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "question": "How does the example agent plan a project?",
+    "workflow": "verified"
+  }' | python3 -m json.tool
+```
+
+The verifier is not controlled by a browser-supplied stage list. The request chooses one of two
+closed policies; the backend owns agent order, run ID, checks, outcomes, and fallback content.
+
+### Step 6 — prove the browser rejects malformed traces
 
 Run:
 
@@ -144,6 +195,9 @@ Review tests for:
 - unsupported agent names/outcomes;
 - invalid metrics;
 - wrong workflow or mode.
+
+Also inspect the failure-injection test that injects an `UnsupportedWriter`. It proves a writer that
+drops expected citations cannot make the verified workflow return its candidate answer.
 
 Add one malformed fixture of your own and assert `invalid_trace`.
 
@@ -200,15 +254,19 @@ silently flattened into a normal answer.
 3. Why should a trace avoid complete prompts even when debugging is easier with them?
 4. How does runtime browser validation reduce damage from a compromised or incompatible server?
 5. Which telemetry belongs only in access-controlled operations logs?
+6. Why does the verifier run after the writer rather than replacing the critic?
+7. Which claim about answer quality would still be unjustified after all verifier checks pass?
 
 ## Completion checklist
 
 - [ ] I observed approved and blocked paths in the browser.
+- [ ] I compared baseline and verified traces.
 - [ ] I inspected the raw JSON for both paths.
 - [ ] I can state the critic's exact current rule.
 - [ ] I added one invalid-trace parser test.
 - [ ] I completed a trace-field threat model.
 - [ ] I can distinguish operational trace data from chain-of-thought.
+- [ ] I can explain the verifier's fail-closed behavior and its semantic limitations.
 
 ## Further reading
 

--- a/course/06-evaluation/README.md
+++ b/course/06-evaluation/README.md
@@ -27,7 +27,7 @@ By the end, you can:
 | --- | --- | --- |
 | Unit test | critic with no matches blocks | Does one component preserve an invariant? |
 | Contract test | malformed stage order is rejected | Do producer and consumer agree on shape? |
-| Integration test | FastAPI route returns four stages | Do components work together? |
+| Integration test | FastAPI route returns four baseline or five verified stages | Do components work together? |
 | Security test | oversized body is rejected | Does an abuse boundary hold? |
 | Behavioral evaluation | expected grounded decision | Does user-visible behavior match labeled cases? |
 | Container smoke test | built services answer a request | Does the packaged stack run? |
@@ -86,6 +86,16 @@ python3 -m json.tool /tmp/agent-me-eval.json
 ```
 
 CI uses this form because it is deterministic and parsable.
+
+Run the same labeled cases through the five-stage policy:
+
+```bash
+.venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json
+```
+
+The expected grounded labels stay unchanged; the second command proves the verifier path preserves
+the known decisions while exercising its additional contract gate. It still does not measure
+semantic entailment or generalize beyond the committed fixture and knowledge files.
 
 ### Step 3 — add a small evaluation matrix
 

--- a/course/07-production-capstone/README.md
+++ b/course/07-production-capstone/README.md
@@ -34,6 +34,7 @@ The baseline implements and tests:
 - server-controlled run IDs;
 - frozen internal handoff artifacts;
 - approved and blocked critic paths;
+- optional post-write verification with fail-closed citation invariants;
 - strict browser response parsing;
 - safe plain-text rendering;
 - no persistence of questions or collaboration traces;
@@ -107,10 +108,11 @@ For each file, write which guarantee would be lost or need redesign after adding
 
 Choose **one** bounded implementation. Depth and evidence matter more than feature count.
 
-### Option A — Verifier role
+### Option A — Extend the verifier policy
 
-Add a fifth typed role that checks mechanical invariants. Update backend, public schema, frontend
-parser/UI, tests, evaluation, and diagrams.
+The reference implementation now includes a fifth typed verifier role. Extend it with one measured
+policy such as citation syntax parsing, per-source allowlists, or claim-to-source mapping. Add
+positive, negative, and false-positive cases; do not rename mechanical checks as truth verification.
 
 ### Option B — Retrieval quality upgrade
 
@@ -237,9 +239,23 @@ Produce:
 
 Base course:
 
-> Built and tested a four-role, in-process multi-agent orchestration workflow (planner → researcher
-> → critic → writer) with typed immutable handoffs, grounded Markdown retrieval, abstention,
-> inspectable operational traces, deterministic evaluations, and a FastAPI/React interface.
+> Built and tested a backward-compatible in-process multi-agent orchestration API with baseline
+> (planner → researcher → critic → writer) and verified (+ verifier) policies, typed immutable
+> handoffs, grounded Markdown retrieval, fail-closed citation invariants, runtime-validated traces,
+> deterministic evaluations, and a FastAPI/React/TypeScript interface.
+
+What that sentence is evidence for:
+
+| Claim | Repository evidence |
+| --- | --- |
+| backward-compatible policies | strict `workflow` request enum and separate workflow identifiers |
+| typed handoffs | frozen Python dataclasses, Pydantic response models, TypeScript types |
+| fail-closed verification | verifier replaces a rejected candidate with a fixed safe response |
+| contract validation | Python route tests plus TypeScript runtime parser tests |
+| end-to-end integration | container CI calls the API through the same-origin Nginx gateway |
+
+It is not evidence for distributed workers, multiple LLMs, semantic truth guarantees, or production
+SLOs. State those as future design work unless you implement and measure them.
 
 After your capstone, add only measured facts:
 

--- a/course/translations/zh-CN/04-typed-orchestration/README.md
+++ b/course/translations/zh-CN/04-typed-orchestration/README.md
@@ -123,7 +123,9 @@ make evaluate
 
 ### 高级：公开 workflow 版本
 
-比较新 endpoint、workflow discriminator 和 API 版本，设计四阶段客户端如何识别未来五阶段响应。
+比较已实现的 `baseline` 与 `verified` 策略，解释 workflow discriminator 如何让客户端先选择
+四阶段或五阶段协议，再验证角色顺序。新增一个 parser 测试：给 verified workflow 提供四阶段
+trace，并确认客户端拒绝它。
 
 ## 理解检查
 

--- a/course/translations/zh-CN/05-critic-observability/README.md
+++ b/course/translations/zh-CN/05-critic-observability/README.md
@@ -27,6 +27,19 @@ Critique(grounded: bool, query_coverage: float)
 
 当前策略：有至少一个 match 就批准，否则阻断。Coverage 只记录、不参与阈值。更强版本可以检查最小分数、覆盖率、矛盾、来源时效/权威、claim-to-source entailment、逐句引用或领域权限，但每个检查都必须评估误报/漏报并定义失败行为。
 
+### Critic 与 Verifier 是两个不同的门
+
+页面现在提供两种协作策略：
+
+| 策略 | 阶段 | 作用 |
+| --- | --- | --- |
+| `baseline` | planner → researcher → critic → writer | 稳定的四阶段教学协议 |
+| `verified` | planner → researcher → critic → writer → verifier | 增加写作后的输出不变量检查 |
+
+Critic 在写作前判断证据是否允许继续；Verifier 在写作后检查候选工件：writer 报告的引用数必须等于唯一证据路径数、每个路径必须以 `[path]` 出现在回答中、无证据固定回复必须保持零引用。
+
+任何检查失败时，Verifier 会阻断候选回答，把 `grounded` 改为 `false`，并换成服务端固定失败文案。这能捕获交接损坏、引用丢失和不兼容 writer，但不能证明自然语言 claim 一定被来源蕴含，更不能称为“真理验证”。
+
 ### 安全 trace 与 chain-of-thought
 
 | 可以公开的运行信息 | 不应作为 trace 公开 |
@@ -42,7 +55,7 @@ Telemetry 回答“发生了什么、在哪里”，不声称暴露模型私有�
 
 ## 阅读实现
 
-依次阅读：[`CriticAgent` 与 trace](../../../../backend/app/collaboration.py)、[公开 trace schema](../../../../backend/app/schemas.py)、[浏览器运行校验](../../../../frontend/src/api.ts)、[UI](../../../../frontend/src/App.tsx)、[parser/UI 测试](../../../../frontend/src/api.test.ts)。
+依次阅读：[`CriticAgent`、`VerifierAgent` 与 trace](../../../../backend/app/collaboration.py)、[公开 trace schema](../../../../backend/app/schemas.py)、[浏览器运行校验](../../../../frontend/src/api.ts)、[UI](../../../../frontend/src/App.tsx)、[parser/UI 测试](../../../../frontend/src/api.test.ts)。
 
 ## 动手实验
 
@@ -74,6 +87,19 @@ Explain quantum chromodynamics renormalization.
 ```
 
 确认 researcher 证据为 0、critic `blocked`、writer 正常返回证据不足、来源为空且引用 0。阻断是成功策略结果，不是请求崩溃。
+
+### 验证路径
+
+选择 **已验证多 Agent**，再次提交有依据的问题，确认 workflow 以 `-verifier` 结尾、trace 有五个有序阶段，且 verifier 显示 `approved`、`citation_paths_valid`、期望引用数和报告引用数。
+
+```bash
+curl --silent http://localhost:8000/api/v1/collaborate \
+  --header 'Content-Type: application/json' \
+  --data '{"question":"How does the example agent plan a project?","workflow":"verified"}' \
+  | python3 -m json.tool
+```
+
+请求只能从封闭枚举中选择策略；角色顺序、run ID、检查结果与失败文案都由服务端控制。阅读注入 `UnsupportedWriter` 的后端测试，确认丢失引用的候选回答不能通过。
 
 ### 检查原始 JSON 与 parser
 
@@ -113,6 +139,8 @@ npm test -- --run src/api.test.ts
 3. 为什么调试方便也不应保存完整 prompt？
 4. 浏览器运行校验如何降低不兼容/被破坏服务端风险？
 5. 哪些 telemetry 只应在受权限保护的日志？
+6. 为什么 Verifier 位于 Writer 之后，而不能替代 Critic？
+7. 所有机械检查通过后，仍然不能声称哪种质量保证？
 
 ## 完成清单
 
@@ -122,6 +150,7 @@ npm test -- --run src/api.test.ts
 - [ ] 新增一个非法 trace parser 测试。
 - [ ] 完成 trace 字段威胁模型。
 - [ ] 能区分运行轨迹和 chain-of-thought。
+- [ ] 对比 baseline 与 verified trace，并能解释 fail-closed 及其语义限制。
 
 ## 延伸阅读
 

--- a/course/translations/zh-CN/06-evaluation/README.md
+++ b/course/translations/zh-CN/06-evaluation/README.md
@@ -23,7 +23,7 @@
 | --- | --- | --- |
 | 单元测试 | 无 match 时 critic 阻断 | 单组件是否保持不变量？ |
 | 协议测试 | 乱序 stage 被拒绝 | 生产者/消费者是否一致？ |
-| 集成测试 | FastAPI 返回四阶段 | 组件能否共同工作？ |
+| 集成测试 | FastAPI 返回四阶段 baseline 或五阶段 verified trace | 组件能否共同工作？ |
 | 安全测试 | 超大 body 被拒绝 | 滥用边界是否有效？ |
 | 行为评估 | grounded 是否符合标签 | 用户可见行为是否符合预期？ |
 | 容器 smoke | 构建服务能回答 | 打包栈是否运行？ |
@@ -58,6 +58,14 @@ make evaluate
 .venv/bin/python scripts/evaluate_collaboration.py --json > /tmp/agent-me-eval.json
 python3 -m json.tool /tmp/agent-me-eval.json
 ```
+
+再让同一组标签用例通过五阶段策略：
+
+```bash
+.venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json
+```
+
+预期 grounded 标签保持不变；第二条命令证明 verifier 路径在执行新增协议门控时没有破坏已知决定。它仍不能度量语义蕴含，也不能泛化到已提交 fixture 与知识文件之外。
 
 新增至少三例：直接支持事实、无依据领域问题、较少精确 token 的 paraphrase。ID 必须稳定唯一；标签应来自 committed corpus，而不是“当前代码返回了什么”。
 

--- a/course/translations/zh-CN/07-production-capstone/README.md
+++ b/course/translations/zh-CN/07-production-capstone/README.md
@@ -22,7 +22,7 @@
 
 ## 原理：当前保证与缺失保证
 
-当前已实现并测试：严格 request/body 限制、确定性本地检索与角色顺序、服务端 run ID、frozen 工件、批准/阻断路径、严格浏览器解析、安全纯文本、不持久化问题/trace、CI/评估/容器 smoke。
+当前已实现并测试：严格 request/body 限制、确定性本地检索与角色顺序、服务端 run ID、frozen 工件、批准/阻断路径、可选的 fail-closed 引用不变量验证、严格浏览器解析、安全纯文本、不持久化问题/trace、CI/评估/容器 smoke。
 
 当前没有：重启后持久状态、多 Worker 协调、exactly-once、provider 冗余/预算、认证授权/tenant 隔离、加密 trace/retention job、生产规模语义检索、形式化忠实度、SLO 与事故响应。
 
@@ -56,7 +56,7 @@ Worker 原子 claim stage，幂等写输出，再 append event。
 
 只选一个，深度与证据优先于功能数量：
 
-1. **Verifier role：**加入第五个类型化角色，同步后端、schema、前端、测试、评估和图。
+1. **扩展 Verifier 策略：**参考实现已包含第五个类型化角色；继续实现引用语法解析、来源 allowlist 或 claim-to-source mapping，并加入正例、反例和误报用例。不要把机械检查包装成真理验证。
 2. **检索升级：**配置第二种排序，建立 relevance label，对比 precision/recall 和 latency，保留 fallback。
 3. **持久本地 run：**SQLite/PostgreSQL + migration + 幂等状态，加入重启/重复执行测试，默认不保存 raw prompt。
 4. **认证与 tenant 隔离：**使用成熟认证，把 knowledge/run 按 tenant 约束，测试 IDOR、授权、删除、密钥脱敏。
@@ -129,7 +129,9 @@ make build
 
 准确简历写法：
 
-> 构建并测试了一个单进程四角色 multi-agent 编排流程（planner → researcher → critic → writer），包含不可变类型化交接、本地 grounded 检索、拒答、运行轨迹、确定性评估与 FastAPI/React 界面。
+> 构建并测试了向后兼容的单进程 multi-agent 编排 API，包含 baseline（planner → researcher → critic → writer）和 verified（+ verifier）策略、不可变类型化交接、本地 grounded 检索、fail-closed 引用不变量、运行时校验 trace、确定性评估，以及 FastAPI/React/TypeScript 界面。
+
+这句话的证据包括：严格 `workflow` 枚举与不同 workflow ID、Python frozen dataclass/Pydantic/TypeScript 三层协议、拒绝候选回答的失败注入测试、Python route 与浏览器 parser 合同测试，以及经过 Nginx 同源网关的容器 CI。它不代表分布式 Worker、多 LLM、形式化真值保证或生产 SLO。
 
 新增度量后才写具体数字。除非已实现和测试，不要写 distributed、autonomous、production-ready、hallucination-free 或 multiple LLMs。
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,13 +28,19 @@ The application rejects HTTP request bodies larger than `MAX_REQUEST_BODY_BYTES`
 
 ## `POST /api/v1/collaborate`
 
-Runs the local planner → researcher → critic → writer learning workflow. The request is a strict object containing only a required nonblank `question`, capped by `MAX_QUESTION_CHARS`:
+Runs the local planner → researcher → critic → writer learning workflow. The request is a strict
+object containing a required nonblank `question`, capped by `MAX_QUESTION_CHARS`, and an optional
+`workflow` policy:
 
 ```json
 {
-  "question": "How does the example agent plan a project?"
+  "question": "How does the example agent plan a project?",
+  "workflow": "baseline"
 }
 ```
+
+`workflow` is either `baseline` (the default four-stage contract) or `verified` (the same four
+stages followed by a mechanical verifier). Unknown values and fields are rejected with `422`.
 
 The response contains a server-generated run ID, the fixed workflow and mode identifiers, a grounded decision, sources, and four ordered operational trace stages:
 
@@ -63,7 +69,25 @@ The response contains a server-generated run ID, the fixed workflow and mode ide
 
 The actual response always contains planner, researcher, critic, and writer stages in that order. The shortened example shows only the first stage. Trace summaries describe workflow operations and counts; they are not hidden model reasoning. This endpoint is deterministic, local, and does not use `LLM_BASE_URL`.
 
-When retrieval finds no evidence, `grounded` is `false`, the critic outcome is `blocked`, and the writer returns the fixed insufficient-evidence message with zero citations.
+For the verified policy, submit:
+
+```json
+{
+  "question": "How does the example agent plan a project?",
+  "workflow": "verified"
+}
+```
+
+Its response uses `workflow: "planner-researcher-critic-writer-verifier"` and appends a fifth
+`verifier` stage. The verifier independently checks that the writer-reported citation count matches
+the unique evidence paths and that every expected path occurs in the answer. If an invariant fails,
+the stage is `blocked`, the candidate answer is discarded, `grounded` becomes `false`, and the API
+returns a fixed safe verification-failure message. This is output-contract verification, not a
+semantic proof that every natural-language claim is true.
+
+When retrieval finds no evidence, `grounded` is `false`, the critic outcome is `blocked`, and the
+writer returns the fixed insufficient-evidence message with zero citations. In verified mode, the
+verifier records that this safe fallback satisfies the zero-citation invariant.
 
 ## Request-size errors
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,8 @@ the filesystem remains authoritative after edits and process restarts.
 ## Multi-agent learning path
 
 `POST /api/v1/collaborate` injects the same bounded Markdown retriever used by the single-path API
-into the collaboration workflow and runs four local roles in a fixed order:
+into the collaboration workflow. The default policy runs four local roles in a fixed order; the
+optional verified policy adds a final output-contract gate:
 
 ```mermaid
 sequenceDiagram
@@ -36,21 +37,31 @@ sequenceDiagram
   participant R as Researcher
   participant C as Critic
   participant W as Writer
+  participant V as Verifier
   API->>P: normalized question
   P-->>R: Plan
   R-->>C: EvidenceBundle
   C-->>W: Critique (approved or blocked)
-  W-->>API: WrittenAnswer
+  W-->>API: WrittenAnswer (baseline)
+  W-->>V: WrittenAnswer + EvidenceBundle (verified)
+  V-->>API: approved or blocked
 ```
 
 The planner stores the normalized retrieval query in an immutable `Plan`. The researcher receives
 that exact plan and owns the retriever call that turns it into an `EvidenceBundle`; retrieval is not
 precomputed at the HTTP boundary. The remaining role artifacts are also frozen dataclasses. The
-orchestrator owns ordering and produces a server-controlled run ID plus four operational trace
-stages. A trace stage contains a role identifier, outcome, safe summary, and numeric/boolean
+orchestrator owns ordering and produces a server-controlled run ID plus four or five operational
+trace stages. A trace stage contains a role identifier, outcome, safe summary, and numeric/boolean
 metrics. It is an audit-friendly workflow record, not model chain-of-thought.
 
 The critic approves synthesis only when retrieval produced evidence. Without evidence it emits a blocked outcome and the writer returns a fixed insufficient-evidence response with zero citations. The default collaboration workflow never calls the optional external provider.
+
+`workflow="verified"` keeps the baseline contract available while appending `VerifierAgent`. This
+role checks mechanical invariants after writing: expected evidence paths must appear as citations,
+and the reported citation count must equal the unique evidence-path count. A failed check replaces
+the candidate with a server-controlled fallback instead of leaking an unverified answer. It does
+not perform entailment, contradiction detection, or formal truth verification; those require a
+labeled evaluation set and a stronger policy.
 
 This is intentionally an in-process, sequential teaching implementation. Moving stages to distributed workers would require durable state, idempotency, delivery semantics, timeouts, retries, cancellation, authorization, and trace-retention controls. See the [hands-on course](../course/README.md) for the implementation and design exercises.
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -277,7 +277,48 @@ it("runs the multi-agent lab and renders its ordered operational trace", async (
     expect.stringContaining("/api/v1/collaborate"),
     expect.objectContaining({
       method: "POST",
-      body: JSON.stringify({ question: "How should I plan?" }),
+      body: JSON.stringify({ question: "How should I plan?", workflow: "baseline" }),
+    }),
+  );
+});
+
+it("runs verified collaboration and renders the verifier handoff", async () => {
+  const fetchMock = vi.fn().mockImplementation((url: string) => {
+    if (url.endsWith("/api/v1/profile")) return Promise.resolve(profileResponse);
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({
+        run_id: `run_${"c".repeat(32)}`,
+        workflow: "planner-researcher-critic-writer-verifier",
+        mode: "multi-agent-local",
+        answer: "Verified answer.\n\nSources: [example.md]",
+        grounded: true,
+        sources: [],
+        trace: ["planner", "researcher", "critic", "writer", "verifier"].map(
+          (agent, index) => ({
+            sequence: index + 1,
+            agent,
+            outcome: "completed",
+            summary: `${agent} completed its handoff.`,
+            metrics: { approved: true },
+          }),
+        ),
+      }),
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  render(<App />);
+  await userEvent.click(screen.getByRole("radio", { name: "Verified multi-agent" }));
+  await userEvent.type(screen.getByLabelText(/ask the example/i), "Verify this answer");
+  await userEvent.click(screen.getByRole("button", { name: "Ask" }));
+
+  expect(await screen.findByText("verifier")).toBeInTheDocument();
+  expect(screen.getByText("verified multi-agent")).toBeInTheDocument();
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining("/api/v1/collaborate"),
+    expect.objectContaining({
+      body: JSON.stringify({ question: "Verify this answer", workflow: "verified" }),
     }),
   );
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import {
 import "./styles.css";
 
 const DEFAULT_MAX_QUESTION_CHARS = 8000;
-type WorkflowMode = "standard" | "collaboration";
+type WorkflowMode = "standard" | "collaboration" | "verified";
 
 export function App() {
   const [locale, setLocale] = useState<Locale>(initialLocale);
@@ -72,9 +72,12 @@ export function App() {
     setResult(null);
     try {
       setResult(
-        workflowMode === "collaboration"
-          ? await collaborate(question.trim())
-          : await ask(question.trim()),
+        workflowMode === "standard"
+          ? await ask(question.trim())
+          : await collaborate(
+              question.trim(),
+              workflowMode === "verified" ? "verified" : "baseline",
+            ),
       );
     } catch (reason) {
       const detail = reason instanceof ApiError ? reason.message : "";
@@ -86,7 +89,9 @@ export function App() {
 
   const modeLabel =
     result?.mode === "multi-agent-local"
-      ? text.collaborationModeLabel
+      ? result.workflow === "planner-researcher-critic-writer-verifier"
+        ? text.verifiedModeLabel
+        : text.collaborationModeLabel
       : result?.mode === "extractive"
       ? text.extractiveMode
       : result?.mode === "openai-compatible"
@@ -147,9 +152,23 @@ export function App() {
               />
               {text.collaborationWorkflow}
             </label>
+            <label>
+              <input
+                type="radio"
+                name="workflow"
+                value="verified"
+                checked={workflowMode === "verified"}
+                onChange={() => setWorkflowMode("verified")}
+                disabled={loading}
+              />
+              {text.verifiedWorkflow}
+            </label>
           </div>
           {workflowMode === "collaboration" && (
             <p className="workflow-hint">{text.collaborationHint}</p>
+          )}
+          {workflowMode === "verified" && (
+            <p className="workflow-hint">{text.verifiedHint}</p>
           )}
         </fieldset>
         <label htmlFor="question">{text.formLabel}</label>

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -78,8 +78,66 @@ it("returns a typed multi-agent collaboration trace", async () => {
   await expect(collaborate("Question")).resolves.toEqual(payload);
   expect(fetchMock).toHaveBeenCalledWith(
     expect.stringContaining("/api/v1/collaborate"),
-    expect.objectContaining({ body: JSON.stringify({ question: "Question" }) }),
+    expect.objectContaining({
+      body: JSON.stringify({ question: "Question", workflow: "baseline" }),
+    }),
   );
+});
+
+it("accepts the verified five-stage workflow and submits the explicit policy", async () => {
+  const payload = {
+    run_id: `run_${"c".repeat(32)}`,
+    workflow: "planner-researcher-critic-writer-verifier",
+    mode: "multi-agent-local",
+    answer: "Verified answer",
+    grounded: true,
+    sources: [],
+    trace: ["planner", "researcher", "critic", "writer", "verifier"].map(
+      (agent, index) => ({
+        sequence: index + 1,
+        agent,
+        outcome: "completed",
+        summary: `${agent} completed`,
+        metrics: { approved: true },
+      }),
+    ),
+  };
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => payload });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(collaborate("Question", "verified")).resolves.toEqual(payload);
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.stringContaining("/api/v1/collaborate"),
+    expect.objectContaining({
+      body: JSON.stringify({ question: "Question", workflow: "verified" }),
+    }),
+  );
+});
+
+it("rejects a verified workflow that omits its verifier stage", async () => {
+  const payload = {
+    run_id: `run_${"d".repeat(32)}`,
+    workflow: "planner-researcher-critic-writer-verifier",
+    mode: "multi-agent-local",
+    answer: "Incomplete trace",
+    grounded: true,
+    sources: [],
+    trace: ["planner", "researcher", "critic", "writer"].map((agent, index) => ({
+      sequence: index + 1,
+      agent,
+      outcome: "completed",
+      summary: `${agent} completed`,
+      metrics: {},
+    })),
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok: true, json: async () => payload }),
+  );
+
+  await expect(collaborate("Question", "verified")).rejects.toMatchObject({
+    code: "invalid_trace",
+  });
 });
 
 it("rejects malformed multi-agent traces", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,11 @@
 export type AnswerMode = "extractive" | "openai-compatible";
 export type Source = { title: string; path: string; excerpt: string; score: number };
 export type ChatResponse = { answer: string; mode: AnswerMode; sources: Source[] };
-export type CollaborationAgent = "planner" | "researcher" | "critic" | "writer";
+export type CollaborationAgent = "planner" | "researcher" | "critic" | "writer" | "verifier";
+export type CollaborationPolicy = "baseline" | "verified";
+export type CollaborationWorkflow =
+  | "planner-researcher-critic-writer"
+  | "planner-researcher-critic-writer-verifier";
 export type CollaborationOutcome = "completed" | "blocked";
 export type CollaborationStage = {
   sequence: number;
@@ -12,7 +16,7 @@ export type CollaborationStage = {
 };
 export type CollaborationResponse = {
   run_id: string;
-  workflow: "planner-researcher-critic-writer";
+  workflow: CollaborationWorkflow;
   mode: "multi-agent-local";
   answer: string;
   grounded: boolean;
@@ -64,7 +68,8 @@ function isCollaborationStage(value: unknown): value is CollaborationStage {
     (stage.agent === "planner" ||
       stage.agent === "researcher" ||
       stage.agent === "critic" ||
-      stage.agent === "writer") &&
+      stage.agent === "writer" ||
+      stage.agent === "verifier") &&
     (stage.outcome === "completed" || stage.outcome === "blocked") &&
     typeof stage.summary === "string" &&
     !!metrics &&
@@ -117,18 +122,33 @@ function parseCollaborationResponse(value: unknown): CollaborationResponse {
     throw new ApiError("Server returned an invalid collaboration trace.", 502, "invalid_trace");
   }
   const response = value as Record<string, unknown>;
-  const expectedAgents: CollaborationAgent[] = ["planner", "researcher", "critic", "writer"];
+  const workflows: Record<CollaborationWorkflow, CollaborationAgent[]> = {
+    "planner-researcher-critic-writer": ["planner", "researcher", "critic", "writer"],
+    "planner-researcher-critic-writer-verifier": [
+      "planner",
+      "researcher",
+      "critic",
+      "writer",
+      "verifier",
+    ],
+  };
+  const workflow = response.workflow;
+  const expectedAgents =
+    workflow === "planner-researcher-critic-writer" ||
+    workflow === "planner-researcher-critic-writer-verifier"
+      ? workflows[workflow]
+      : undefined;
   if (
     typeof response.run_id !== "string" ||
     !/^run_[0-9a-f]{32}$/.test(response.run_id) ||
-    response.workflow !== "planner-researcher-critic-writer" ||
+    !expectedAgents ||
     response.mode !== "multi-agent-local" ||
     typeof response.answer !== "string" ||
     typeof response.grounded !== "boolean" ||
     !Array.isArray(response.sources) ||
     !response.sources.every(isSource) ||
     !Array.isArray(response.trace) ||
-    response.trace.length !== 4 ||
+    response.trace.length !== expectedAgents.length ||
     !response.trace.every(
       (stage, index) =>
         isCollaborationStage(stage) &&
@@ -167,12 +187,13 @@ export async function ask(question: string, signal?: AbortSignal): Promise<ChatR
 
 export async function collaborate(
   question: string,
+  workflow: CollaborationPolicy = "baseline",
   signal?: AbortSignal,
 ): Promise<CollaborationResponse> {
   const response = await fetch(`${API_BASE}/api/v1/collaborate`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ question }),
+    body: JSON.stringify({ question, workflow }),
     signal,
   });
   if (!response.ok) throw await responseError(response);

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -32,10 +32,13 @@ type Messages = {
   extractiveMode: string;
   providerMode: string;
   collaborationModeLabel: string;
+  verifiedModeLabel: string;
   workflowMode: string;
   standardWorkflow: string;
   collaborationWorkflow: string;
+  verifiedWorkflow: string;
   collaborationHint: string;
+  verifiedHint: string;
   workflowTrace: string;
   grounded: string;
   notGrounded: string;
@@ -70,11 +73,15 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "extractive",
     providerMode: "provider",
     collaborationModeLabel: "multi-agent lab",
+    verifiedModeLabel: "verified multi-agent",
     workflowMode: "Workflow",
     standardWorkflow: "Standard Q&A",
     collaborationWorkflow: "Multi-agent lab",
+    verifiedWorkflow: "Verified multi-agent",
     collaborationHint:
       "Runs planner, researcher, critic, and writer roles with typed, inspectable handoffs.",
+    verifiedHint:
+      "Adds a final verifier that checks citation paths and answer metadata, blocking output when invariants fail.",
     workflowTrace: "Collaboration trace",
     grounded: "Grounded",
     notGrounded: "Insufficient evidence",
@@ -105,10 +112,13 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "本地抽取",
     providerMode: "模型服务",
     collaborationModeLabel: "多 Agent 实验",
+    verifiedModeLabel: "已验证多 Agent",
     workflowMode: "工作流",
     standardWorkflow: "标准问答",
     collaborationWorkflow: "多 Agent 实验",
+    verifiedWorkflow: "已验证多 Agent",
     collaborationHint: "依次运行规划、研究、审查和写作角色，并展示类型化、可检查的交接记录。",
+    verifiedHint: "增加最终验证器，检查引用路径和回答元数据；验证失败时阻止输出。",
     workflowTrace: "协作轨迹",
     grounded: "已有依据",
     notGrounded: "依据不足",
@@ -138,10 +148,13 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "本機擷取",
     providerMode: "模型服務",
     collaborationModeLabel: "多 Agent 實驗",
+    verifiedModeLabel: "已驗證多 Agent",
     workflowMode: "工作流程",
     standardWorkflow: "標準問答",
     collaborationWorkflow: "多 Agent 實驗",
+    verifiedWorkflow: "已驗證多 Agent",
     collaborationHint: "依序執行規劃、研究、審查與寫作角色，並顯示具型別且可檢查的交接紀錄。",
+    verifiedHint: "加入最終驗證器，檢查引用路徑與回答中繼資料；驗證失敗時阻擋輸出。",
     workflowTrace: "協作軌跡",
     grounded: "已有依據",
     notGrounded: "依據不足",
@@ -174,11 +187,15 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "ローカル抽出",
     providerMode: "モデルプロバイダー",
     collaborationModeLabel: "マルチエージェント演習",
+    verifiedModeLabel: "検証付きマルチエージェント",
     workflowMode: "ワークフロー",
     standardWorkflow: "標準 Q&A",
     collaborationWorkflow: "マルチエージェント演習",
+    verifiedWorkflow: "検証付きマルチエージェント",
     collaborationHint:
       "プランナー、リサーチャー、批評者、ライターを順に実行し、型付きの引き継ぎを表示します。",
+    verifiedHint:
+      "最後に検証役を追加し、引用パスと回答メタデータを確認して、不変条件に違反する出力をブロックします。",
     workflowTrace: "協働トレース",
     grounded: "根拠あり",
     notGrounded: "根拠不足",
@@ -211,11 +228,15 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "로컬 추출",
     providerMode: "모델 공급자",
     collaborationModeLabel: "멀티 에이전트 실습",
+    verifiedModeLabel: "검증된 멀티 에이전트",
     workflowMode: "워크플로",
     standardWorkflow: "표준 Q&A",
     collaborationWorkflow: "멀티 에이전트 실습",
+    verifiedWorkflow: "검증된 멀티 에이전트",
     collaborationHint:
       "계획자, 조사자, 비평가, 작성자 역할을 순서대로 실행하고 형식화된 인계 기록을 표시합니다.",
+    verifiedHint:
+      "마지막 검증자가 인용 경로와 답변 메타데이터를 확인하고 불변 조건을 위반한 출력을 차단합니다.",
     workflowTrace: "협업 추적",
     grounded: "근거 있음",
     notGrounded: "근거 부족",
@@ -249,11 +270,15 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "extractivo local",
     providerMode: "proveedor",
     collaborationModeLabel: "laboratorio multiagente",
+    verifiedModeLabel: "multiagente verificado",
     workflowMode: "Flujo de trabajo",
     standardWorkflow: "Preguntas y respuestas",
     collaborationWorkflow: "Laboratorio multiagente",
+    verifiedWorkflow: "Multiagente verificado",
     collaborationHint:
       "Ejecuta los roles de planificación, investigación, crítica y redacción con entregas tipadas e inspeccionables.",
+    verifiedHint:
+      "Añade un verificador final que comprueba rutas de citas y metadatos, bloqueando salidas que incumplan las invariantes.",
     workflowTrace: "Traza de colaboración",
     grounded: "Fundamentado",
     notGrounded: "Evidencia insuficiente",
@@ -287,11 +312,15 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "extraction locale",
     providerMode: "fournisseur",
     collaborationModeLabel: "atelier multi-agent",
+    verifiedModeLabel: "multi-agent vérifié",
     workflowMode: "Flux de travail",
     standardWorkflow: "Questions-réponses standard",
     collaborationWorkflow: "Atelier multi-agent",
+    verifiedWorkflow: "Multi-agent vérifié",
     collaborationHint:
       "Exécute les rôles de planification, recherche, critique et rédaction avec des transmissions typées et inspectables.",
+    verifiedHint:
+      "Ajoute un vérificateur final pour les chemins de citation et les métadonnées, puis bloque toute sortie non conforme.",
     workflowTrace: "Trace de collaboration",
     grounded: "Fondé sur les sources",
     notGrounded: "Preuves insuffisantes",
@@ -325,11 +354,15 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "lokale Extraktion",
     providerMode: "Modellanbieter",
     collaborationModeLabel: "Multi-Agent-Labor",
+    verifiedModeLabel: "verifiziertes Multi-Agent-System",
     workflowMode: "Arbeitsablauf",
     standardWorkflow: "Standard-Q&A",
     collaborationWorkflow: "Multi-Agent-Labor",
+    verifiedWorkflow: "Verifiziertes Multi-Agent-System",
     collaborationHint:
       "Führt Planer, Recherche, Kritik und Redaktion mit typisierten, prüfbaren Übergaben aus.",
+    verifiedHint:
+      "Ergänzt einen abschließenden Prüfer für Zitatpfade und Antwortmetadaten und blockiert Ausgaben bei verletzten Invarianten.",
     workflowTrace: "Zusammenarbeitsprotokoll",
     grounded: "Quellengestützt",
     notGrounded: "Unzureichende Belege",
@@ -363,11 +396,15 @@ export const messages: Record<Locale, Messages> = {
     extractiveMode: "extração local",
     providerMode: "provedor",
     collaborationModeLabel: "laboratório multiagente",
+    verifiedModeLabel: "multiagente verificado",
     workflowMode: "Fluxo de trabalho",
     standardWorkflow: "Perguntas e respostas",
     collaborationWorkflow: "Laboratório multiagente",
+    verifiedWorkflow: "Multiagente verificado",
     collaborationHint:
       "Executa os papéis de planejamento, pesquisa, crítica e redação com transferências tipadas e inspecionáveis.",
+    verifiedHint:
+      "Adiciona um verificador final para caminhos de citação e metadados, bloqueando saídas que violem as invariantes.",
     workflowTrace: "Rastro de colaboração",
     grounded: "Fundamentado",
     notGrounded: "Evidências insuficientes",

--- a/scripts/evaluate_collaboration.py
+++ b/scripts/evaluate_collaboration.py
@@ -56,13 +56,18 @@ def load_cases(path: Path) -> list[dict[str, Any]]:
     return cases
 
 
-def evaluate(cases_path: Path, knowledge_dir: Path) -> list[EvaluationResult]:
+def evaluate(
+    cases_path: Path,
+    knowledge_dir: Path,
+    *,
+    verify: bool = False,
+) -> list[EvaluationResult]:
     cases = load_cases(cases_path)
     knowledge = KnowledgeBase(str(knowledge_dir))
     orchestrator = CollaborationOrchestrator(retriever=knowledge)
     results: list[EvaluationResult] = []
     for case in cases:
-        run = orchestrator.run(question=case["question"])
+        run = orchestrator.run(question=case["question"], verify=verify)
         critic = next(stage for stage in run.trace if stage.agent == "critic")
         expected = case["expected_grounded"]
         results.append(
@@ -91,10 +96,20 @@ def main() -> int:
     parser.add_argument(
         "--json", action="store_true", help="emit machine-readable output"
     )
+    parser.add_argument(
+        "--workflow",
+        choices=("baseline", "verified"),
+        default="baseline",
+        help="choose the four-stage baseline or five-stage verified policy",
+    )
     args = parser.parse_args()
 
     try:
-        results = evaluate(args.cases, args.knowledge_dir)
+        results = evaluate(
+            args.cases,
+            args.knowledge_dir,
+            verify=args.workflow == "verified",
+        )
     except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
         print(f"evaluation setup failed: {error}", file=sys.stderr)
         return 2
@@ -105,7 +120,11 @@ def main() -> int:
             json.dumps(
                 {
                     "results": [asdict(result) for result in results],
-                    "summary": {"passed": passed, "total": len(results)},
+                    "summary": {
+                        "passed": passed,
+                        "total": len(results),
+                        "workflow": args.workflow,
+                    },
                 },
                 indent=2,
             )


### PR DESCRIPTION
## Why

The existing four-role path teaches typed handoffs and critic gating, but it ends immediately after writing. This vertical slice adds a backward-compatible post-write policy gate that is substantial enough to demonstrate contract evolution, failure injection, runtime validation, localization, evaluation, and honest portfolio evidence.

## Implementation

- keep the existing baseline workflow and response contract as the default
- add an explicit verified policy with planner, researcher, critic, writer, and verifier stages
- validate citation paths and reported citation counts after writing
- fail closed with a server-controlled response when verifier invariants fail
- preserve server-controlled IDs, stage order, outcomes, and metrics
- support both contracts in Pydantic and the TypeScript runtime parser
- expose the verified path in the React UI with complete nine-locale copy
- run the deterministic fixture through both policies in CI
- add detailed English and Simplified Chinese labs, architecture notes, limitations, and resume evidence mapping

## Verification

- backend Ruff and format checks pass
- backend tests: 51 passed
- frontend lint and typecheck pass
- frontend tests: 28 passed
- frontend production build passes
- documentation check: 46 Markdown files and 16 maintained lesson pages
- baseline evaluation: 4/4
- verified evaluation: 4/4
- real HTTP through the Vite same-origin gateway: VERIFIED_WORKFLOW_HTTP_PASS
- invalid workflow returns 422

## Scope and honesty

The verifier checks mechanical output invariants. It does not claim semantic entailment, formal truth verification, autonomous processes, multiple models, durable orchestration, or production SLOs.