### PR TITLE
fix(retrieval): support Unicode words across locales

### DIFF
--- a/backend/app/collaboration.py
+++ b/backend/app/collaboration.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import Literal, Protocol, TypeAlias
 from uuid import uuid4
 
 from .knowledge import Match
+from .text import normalized_tokens
 
 AgentName: TypeAlias = Literal["planner", "researcher", "critic", "writer", "verifier"]
 StageOutcome: TypeAlias = Literal["completed", "blocked"]
@@ -15,13 +15,8 @@ WorkflowName: TypeAlias = Literal[
     "planner-researcher-critic-writer-verifier",
 ]
 
-_TOKEN = re.compile(r"[a-z0-9]+|[\u3400-\u9fff]", re.IGNORECASE)
 _INSUFFICIENT_EVIDENCE = "I could not find a grounded answer in the configured knowledge files."
 _VERIFICATION_FAILED = "I could not return a verified answer from the configured knowledge files."
-
-
-def _tokens(value: str) -> set[str]:
-    return {token.lower() for token in _TOKEN.findall(value)}
 
 
 @dataclass(frozen=True)
@@ -91,7 +86,7 @@ class PlannerAgent:
                 "Check whether the evidence supports the requested answer.",
                 "Write a concise answer with source-path citations.",
             ),
-            query_term_count=len(_tokens(retrieval_query)),
+            query_term_count=len(normalized_tokens(retrieval_query)),
         )
 
 
@@ -109,8 +104,8 @@ class CriticAgent:
     name: AgentName = "critic"
 
     def run(self, question: str, evidence: EvidenceBundle) -> Critique:
-        query_tokens = _tokens(question)
-        evidence_tokens = _tokens("\n".join(match.excerpt for match in evidence.matches))
+        query_tokens = normalized_tokens(question)
+        evidence_tokens = normalized_tokens("\n".join(match.excerpt for match in evidence.matches))
         covered = query_tokens & evidence_tokens
         coverage = len(covered) / max(len(query_tokens), 1)
         return Critique(

--- a/backend/app/knowledge.py
+++ b/backend/app/knowledge.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
 
-_TOKEN = re.compile(r"[a-z0-9]+|[\u3400-\u9fff]", re.IGNORECASE)
+from .text import normalized_tokens
+
 _ATX_HEADING = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)(?:\s+#+)?$")
 _MIN_QUERY_COVERAGE = 0.75
 _STOP_WORDS = frozenset(
@@ -79,12 +80,8 @@ class _KnowledgeFile:
     changed_ns: int
 
 
-def _tokens(value: str) -> set[str]:
-    return {token.lower() for token in _TOKEN.findall(value)}
-
-
 def _query_tokens(value: str) -> set[str]:
-    return _tokens(value) - _STOP_WORDS
+    return normalized_tokens(value) - _STOP_WORDS
 
 
 def _title(path: Path, text: str) -> str:
@@ -239,7 +236,7 @@ class KnowledgeBase:
         matches: list[Match] = []
         for document in self.documents():
             for paragraph in _content_chunks(document.text):
-                paragraph_tokens = _tokens(paragraph)
+                paragraph_tokens = normalized_tokens(paragraph)
                 overlap = query & paragraph_tokens
                 score = len(overlap) / len(query)
                 if score < min_score:

--- a/backend/app/text.py
+++ b/backend/app/text.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import unicodedata
+
+
+def _is_han(character: str) -> bool:
+    codepoint = ord(character)
+    return 0x3400 <= codepoint <= 0x9FFF
+
+
+def normalized_tokens(value: str) -> set[str]:
+    """Return deterministic search terms after NFKC normalization and case folding.
+
+    Letters and numbers stay grouped into words. Combining marks stay attached to
+    the word they modify, while Han characters remain individual terms so the
+    starter's existing CJK matching behavior does not change.
+    """
+
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    tokens: set[str] = set()
+    word: list[str] = []
+
+    def flush_word() -> None:
+        if word:
+            tokens.add("".join(word))
+            word.clear()
+
+    for character in normalized:
+        if _is_han(character):
+            flush_word()
+            tokens.add(character)
+        elif character.isalnum():
+            word.append(character)
+        elif unicodedata.category(character).startswith("M") and word:
+            word.append(character)
+        else:
+            flush_word()
+
+    flush_word()
+    return tokens

--- a/backend/tests/test_collaboration.py
+++ b/backend/tests/test_collaboration.py
@@ -93,6 +93,17 @@ def test_planner_output_controls_the_researcher_query() -> None:
     assert result.trace[0].metrics == {"task_count": 1, "query_term_count": 3}
 
 
+def test_collaboration_metrics_use_normalized_unicode_terms() -> None:
+    retriever = StubRetriever([match(excerpt="Le résumé décrit une expérience fiable.")])
+
+    result = CollaborationOrchestrator(retriever=retriever).run(
+        question="RE\u0301SUME\u0301 expérience"
+    )
+
+    assert result.trace[0].metrics["query_term_count"] == 2
+    assert result.trace[2].metrics["query_coverage"] == 1.0
+
+
 def test_verified_workflow_appends_a_typed_verifier_stage() -> None:
     result = CollaborationOrchestrator(retriever=StubRetriever([match()])).run(
         question="How does the agent plan from user goals?",

--- a/backend/tests/test_knowledge.py
+++ b/backend/tests/test_knowledge.py
@@ -69,6 +69,49 @@ def test_search_order_and_limit_are_deterministic(tmp_path: Path) -> None:
     assert [match.document.path for match in matches] == ["a.md"]
 
 
+@pytest.mark.parametrize(
+    ("document_text", "question"),
+    [
+        ("Expérience en ingénierie et rédaction.", "expérience ingénierie"),
+        ("Zuverlässige Systeme lösen größere Probleme.", "zuverlässige größere"),
+        ("Automação confiável para produção.", "automação produção"),
+        ("Evaluación técnica en español.", "evaluación español"),
+    ],
+)
+def test_search_supports_accented_words(
+    tmp_path: Path,
+    document_text: str,
+    question: str,
+) -> None:
+    (tmp_path / "profile.md").write_text(document_text, encoding="utf-8")
+
+    matches = KnowledgeBase(str(tmp_path)).search(question)
+
+    assert len(matches) == 1
+    assert matches[0].score == 1.0
+
+
+def test_search_treats_composed_and_decomposed_accents_equally(tmp_path: Path) -> None:
+    (tmp_path / "profile.md").write_text(
+        "The candidate maintains a résumé for technical interviews.",
+        encoding="utf-8",
+    )
+
+    matches = KnowledgeBase(str(tmp_path)).search("re\u0301sume\u0301 technical")
+
+    assert len(matches) == 1
+    assert matches[0].score == 1.0
+
+
+def test_search_keeps_han_characters_as_individual_terms(tmp_path: Path) -> None:
+    (tmp_path / "profile.md").write_text("可靠的知识检索系统", encoding="utf-8")
+
+    matches = KnowledgeBase(str(tmp_path)).search("可靠检索")
+
+    assert len(matches) == 1
+    assert matches[0].score == 1.0
+
+
 def test_search_ignores_stop_words_instead_of_treating_them_as_evidence(
     tmp_path: Path,
 ) -> None:

--- a/course/02-retrieval/README.md
+++ b/course/02-retrieval/README.md
@@ -32,7 +32,8 @@ Agent-Me uses a deliberately small lexical baseline:
 2. reject symlinks, paths outside the root, invalid UTF-8, and oversized files;
 3. turn each nonempty Markdown block into a candidate chunk;
 4. retain ATX heading text while stripping heading markers;
-5. tokenize ASCII words and individual CJK characters;
+5. apply Unicode NFKC normalization and case folding, then tokenize Unicode words and individual
+   Han characters;
 6. remove a small, explicit set of English stop words from query tokens;
 7. compute overlap between the remaining unique query tokens and chunk tokens;
 8. score `|query ∩ chunk| / |query|` and reject scores below `0.75` by default;
@@ -73,10 +74,11 @@ an empty cache, and the configured filesystem remains authoritative.
 
 ## Read the implementation
 
-Open [`backend/app/knowledge.py`](../../backend/app/knowledge.py) and follow:
+Open [`backend/app/text.py`](../../backend/app/text.py) and then
+[`backend/app/knowledge.py`](../../backend/app/knowledge.py). Follow:
 
-1. `_TOKEN` and `_tokens`;
-2. `_ATX_HEADING` and `_content_chunks`;
+1. `normalized_tokens`;
+2. `_query_tokens`, `_ATX_HEADING`, and `_content_chunks`;
 3. `KnowledgeBase.documents`;
 4. `KnowledgeBase.search`;
 5. `Match`, `Document`, and `KnowledgeLoadError`.
@@ -105,18 +107,21 @@ Use a short Python probe to see the actual tokens:
 
 ```bash
 .venv/bin/python - <<'PY'
-from app.knowledge import _query_tokens, _tokens
+from app.knowledge import _query_tokens
+from app.text import normalized_tokens
 q = "How does the agent plan a project?"
 p = "For project planning, the example agent starts with user goals."
 print("query:", sorted(_query_tokens(q)))
-print("chunk:", sorted(_tokens(p)))
-print("overlap:", sorted(_query_tokens(q) & _tokens(p)))
-print("score:", len(_query_tokens(q) & _tokens(p)) / len(_query_tokens(q)))
+print("chunk:", sorted(normalized_tokens(p)))
+print("overlap:", sorted(_query_tokens(q) & normalized_tokens(p)))
+print("score:", len(_query_tokens(q) & normalized_tokens(p)) / len(_query_tokens(q)))
 PY
 ```
 
-The underscore-prefixed function is used here only as a learning probe; application code should
-not depend on a private helper.
+The underscore-prefixed query helper is used here only as a learning probe; application code
+should not depend on it. `normalized_tokens` is shared by retrieval and collaboration metrics. It
+uses NFKC plus case folding, so composed `résumé` and decomposed `re\u0301sume\u0301` produce the
+same term.
 
 ### Step 3 — inspect ranked matches
 

--- a/course/translations/zh-CN/02-retrieval/README.md
+++ b/course/translations/zh-CN/02-retrieval/README.md
@@ -27,7 +27,7 @@ Agent-Me 使用一个刻意简单的词法基线：
 2. 拒绝 symlink、越界路径、非法 UTF-8 和过大文件；
 3. 把每个非空 Markdown block 变成候选 chunk；
 4. 保留 ATX 标题文字但移除 `#`；
-5. 将 ASCII 单词与每个 CJK 字符分词；
+5. 先做 Unicode NFKC 规范化与大小写折叠，再将 Unicode 单词和每个汉字分词；
 6. 从 query token 中移除一小组明确的英文停用词；
 7. 计算其余 query token 与 chunk token 的交集；
 8. 分数为 `|Q ∩ P| / max(|Q|, 1)`，默认拒绝低于 `0.75` 的结果；
@@ -48,7 +48,9 @@ API route 会在线程池运行同步扫描与检索，避免阻塞 FastAPI 的 
 
 ## 阅读实现
 
-打开 [`backend/app/knowledge.py`](../../../../backend/app/knowledge.py)，依次读 `_TOKEN`、`_tokens`、`_content_chunks`、`documents`、`search` 和数据类；再阅读
+先打开 [`backend/app/text.py`](../../../../backend/app/text.py) 阅读 `normalized_tokens`，再打开
+[`backend/app/knowledge.py`](../../../../backend/app/knowledge.py)，依次读 `_query_tokens`、
+`_content_chunks`、`documents`、`search` 和数据类；再阅读
 [`test_knowledge.py`](../../../../backend/tests/test_knowledge.py)，把每个安全分支对应到测试。
 
 ## 动手实验
@@ -63,17 +65,20 @@ API route 会在线程池运行同步扫描与检索，避免阻塞 FastAPI 的 
 
 ```bash
 .venv/bin/python - <<'PY'
-from app.knowledge import _query_tokens, _tokens
+from app.knowledge import _query_tokens
+from app.text import normalized_tokens
 q = "How does the agent plan a project?"
 p = "For project planning, the example agent starts with user goals."
 print("query:", sorted(_query_tokens(q)))
-print("chunk:", sorted(_tokens(p)))
-print("overlap:", sorted(_query_tokens(q) & _tokens(p)))
-print("score:", len(_query_tokens(q) & _tokens(p)) / len(_query_tokens(q)))
+print("chunk:", sorted(normalized_tokens(p)))
+print("overlap:", sorted(_query_tokens(q) & normalized_tokens(p)))
+print("score:", len(_query_tokens(q) & normalized_tokens(p)) / len(_query_tokens(q)))
 PY
 ```
 
-`_tokens` 是私有 helper，这里只用于学习探针，不应成为应用外部依赖。
+`_query_tokens` 是私有 helper，这里只用于学习探针，不应成为应用外部依赖。
+`normalized_tokens` 由检索评分与协作覆盖率指标共同使用。它采用 NFKC 加大小写折叠，
+所以组合形式 `résumé` 与分解形式 `re\u0301sume\u0301` 会得到相同 token。
 
 打印排序结果：
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,11 @@ and returns up to four sources that meet the default `0.75` threshold. If all pr
 present, the service calls the provider's `/chat/completions` route using a grounded system message.
 Otherwise it returns the highest-ranked excerpt.
 
+Tokenization applies Unicode NFKC normalization followed by case folding. Unicode letters and
+numbers remain word tokens, while Han characters remain individual tokens to preserve the
+starter's deterministic CJK behavior. Retrieval scoring and collaboration coverage metrics share
+this implementation so canonically equivalent text is treated consistently.
+
 The API reuses `KnowledgeBase` instances for identical roots and size limits. Every access still
 rescans bounded file metadata and re-enforces the root, symlink, file-type, and size rules; unchanged
 signatures reuse immutable parsed documents, while add/edit/remove operations invalidate the cache.


### PR DESCRIPTION
## Summary

- centralize retrieval and collaboration tokenization in one dependency-free helper
- apply Unicode NFKC normalization plus case folding while preserving per-character Han matching
- cover French, German, Portuguese, Spanish, canonically equivalent accents, and CJK behavior
- update English/Chinese retrieval lessons and architecture documentation

## Why

The previous ASCII-only expression discarded accented letters used by advertised locales and was duplicated across two workflow modules.

## Validation

- `.venv/bin/ruff check backend scripts`
- `.venv/bin/ruff format --check backend scripts`
- `.venv/bin/pytest -q backend/tests/test_knowledge.py backend/tests/test_collaboration.py` — 24 passed
- `python3 scripts/check_docs.py` — passed
- `.venv/bin/python scripts/evaluate_collaboration.py --json` — 4/4 passed

## Compatibility and privacy

No API schema or dependency changes. ASCII behavior and individual Han-character matching remain stable. No request or knowledge content is logged or persisted.

Closes #35
