### PR TITLE
ci: test the minimum supported Python runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,27 @@ jobs:
       - run: .venv/bin/python scripts/evaluate_collaboration.py --json
       - run: .venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json
 
+  python-minimum:
+    name: Python 3.11 compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.7"
+          python-version: "3.11"
+          enable-cache: true
+          cache-dependency-glob: backend/uv.lock
+      - run: uv lock --project backend --check
+      - run: uv sync --project backend --locked --extra dev --python 3.11
+        env: { UV_PROJECT_ENVIRONMENT: "${{ github.workspace }}/.venv" }
+      - run: .venv/bin/pytest backend/tests
+      - run: .venv/bin/python scripts/evaluate_collaboration.py --json
+      - run: .venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json
+
   frontend:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/course/00-course-setup/README.md
+++ b/course/00-course-setup/README.md
@@ -105,7 +105,8 @@ npm --version
 git --version
 ```
 
-Python must be 3.11 or newer, uv must be 0.11 or 0.12, and Node.js must be 22 or newer.
+Python 3.11 is the minimum supported and tested runtime; Python 3.12 is recommended and used by
+the primary CI job and Dev Container. uv must be 0.11 or 0.12, and Node.js must be 22 or newer.
 [Install uv](https://docs.astral.sh/uv/getting-started/installation/), then install and validate:
 
 ```bash

--- a/course/translations/zh-CN/00-course-setup/README.md
+++ b/course/translations/zh-CN/00-course-setup/README.md
@@ -72,7 +72,7 @@ curl --fail http://127.0.0.1:5173/ >/dev/null
 docker compose down --volumes
 ```
 
-本地工具链（Python 3.11+、uv 0.11/0.12、Node 22+）：
+本地工具链（最低支持并测试 Python 3.11；推荐 Python 3.12；uv 0.11/0.12；Node 22+）：
 
 ```bash
 make setup


### PR DESCRIPTION
## Summary

- add a separate read-only Python 3.11 compatibility job
- install the locked development environment with the pinned setup-uv action
- run backend tests and both deterministic collaboration policies on the minimum runtime
- document Python 3.11 as tested minimum and Python 3.12 as recommended in English and Simplified Chinese Lesson 00

## Verification

- `UV_PROJECT_ENVIRONMENT=<temp> uv sync --project backend --locked --extra dev --python 3.11`
- Python 3.11.15: `64 passed`
- baseline evaluation: `4/4 passed`
- verified evaluation: `4/4 passed`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_versions.py`
- `git diff --check`

Fixes #83