### PR TITLE
frontend: add accessible copy actions for answers and sources

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -328,6 +328,86 @@ it("runs verified collaboration and renders the verifier handoff", async () => {
   );
 });
 
+it("copies the answer and sources as deterministic plain text", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  vi.stubGlobal(
+    "fetch",
+    routeFetch({
+      answer: "Start with user goals.",
+      mode: "extractive",
+      sources: [
+        { title: "First", path: "first.md", excerpt: "…", score: 1 },
+        { title: "Second", path: "second.md", excerpt: "…", score: 0.5 },
+      ],
+    }),
+  );
+
+  render(<App />);
+  await userEvent.type(screen.getByLabelText(/ask the example/i), "How do I plan?");
+  await userEvent.click(screen.getByRole("button", { name: "Ask" }));
+  await screen.findByText("Start with user goals.", { selector: ".answer > p" });
+
+  await userEvent.click(screen.getByRole("button", { name: "Copy answer" }));
+  expect(writeText).toHaveBeenCalledWith("Start with user goals.");
+  expect(await screen.findByRole("status")).toHaveTextContent("Answer copied to clipboard.");
+
+  await userEvent.click(screen.getByRole("button", { name: "Copy sources" }));
+  expect(writeText).toHaveBeenLastCalledWith("First — first.md\nSecond — second.md");
+  expect(await screen.findByRole("status")).toHaveTextContent("Sources copied to clipboard.");
+});
+
+it("hides the copy sources control when there are no sources", async () => {
+  vi.stubGlobal(
+    "fetch",
+    routeFetch({
+      answer: "The supplied context is insufficient.",
+      mode: "openai-compatible",
+      sources: [],
+    }),
+  );
+
+  render(<App />);
+  await userEvent.type(screen.getByLabelText(/ask the example/i), "Unknown question");
+  await userEvent.click(screen.getByRole("button", { name: "Ask" }));
+  await screen.findByText("The supplied context is insufficient.", { selector: ".answer > p" });
+
+  expect(screen.getByRole("button", { name: "Copy answer" })).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "Copy sources" })).not.toBeInTheDocument();
+});
+
+it("shows a safe localized message when the clipboard write fails", async () => {
+  const writeText = vi.fn().mockRejectedValue(new DOMException("denied", "NotAllowedError"));
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  vi.stubGlobal(
+    "fetch",
+    routeFetch({
+      answer: "Start with user goals.",
+      mode: "extractive",
+      sources: [],
+    }),
+  );
+
+  render(<App />);
+  await userEvent.type(screen.getByLabelText(/ask the example/i), "How do I plan?");
+  await userEvent.click(screen.getByRole("button", { name: "Ask" }));
+  await screen.findByText("Start with user goals.", { selector: ".answer > p" });
+
+  await userEvent.click(screen.getByRole("button", { name: "Copy answer" }));
+
+  const status = await screen.findByRole("status");
+  expect(status).toHaveTextContent("Copy failed. Select and copy the text manually.");
+  expect(status.textContent).not.toMatch(/NotAllowedError|denied/);
+});
+
 it("exports only the validated collaboration response and revokes its object URL", () => {
   let blobParts: BlobPart[] = [];
   const createObjectURL = vi.fn(() => "blob:run");

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,10 @@ import "./styles.css";
 const DEFAULT_MAX_QUESTION_CHARS = 8000;
 type WorkflowMode = "standard" | "collaboration" | "verified";
 
+function formatSourcesForCopy(sources: readonly { title: string; path: string }[]): string {
+  return sources.map((source) => `${source.title} — ${source.path}`).join("\n");
+}
+
 export function App() {
   const [locale, setLocale] = useState<Locale>(initialLocale);
   const [question, setQuestion] = useState("");
@@ -29,6 +33,7 @@ export function App() {
   const [loading, setLoading] = useState(false);
   const [profile, setProfile] = useState<ProfileResponse | null>(null);
   const [workflowMode, setWorkflowMode] = useState<WorkflowMode>("standard");
+  const [copyStatus, setCopyStatus] = useState("");
   const text = messages[locale];
   const maxQuestionChars = profile?.max_question_chars ?? DEFAULT_MAX_QUESTION_CHARS;
   const privacyMessage = profile
@@ -71,6 +76,7 @@ export function App() {
     setLoading(true);
     setError("");
     setResult(null);
+    setCopyStatus("");
     try {
       setResult(
         workflowMode === "standard"
@@ -85,6 +91,16 @@ export function App() {
       setError(detail ? `${text.requestFailed}: ${detail}` : text.requestFailed);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function copyToClipboard(value: string, successMessage: string) {
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error("clipboard unavailable");
+      await navigator.clipboard.writeText(value);
+      setCopyStatus(successMessage);
+    } catch {
+      setCopyStatus(text.copyFailure);
     }
   }
 
@@ -208,6 +224,31 @@ export function App() {
             <span>{modeLabel}</span>
           </div>
           <p>{result.answer}</p>
+          <div className="copy-actions">
+            {result.answer.trim() && (
+              <button
+                type="button"
+                onClick={() => copyToClipboard(result.answer, text.copyAnswerSuccess)}
+              >
+                {text.copyAnswer}
+              </button>
+            )}
+            {result.sources.length > 0 && (
+              <button
+                type="button"
+                onClick={() =>
+                  copyToClipboard(formatSourcesForCopy(result.sources), text.copySourcesSuccess)
+                }
+              >
+                {text.copySources}
+              </button>
+            )}
+          </div>
+          {copyStatus && (
+            <p role="status" className="copy-status">
+              {copyStatus}
+            </p>
+          )}
           <h3>{text.groundingSources}</h3>
           {result.sources.length > 0 ? (
             <ul>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -47,6 +47,11 @@ type Messages = {
   runId: string;
   exportRun: string;
   exportPrivacy: string;
+  copyAnswer: string;
+  copySources: string;
+  copyAnswerSuccess: string;
+  copySourcesSuccess: string;
+  copyFailure: string;
   footer: string;
 };
 
@@ -92,6 +97,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "Run ID",
     exportRun: "Download sanitized run JSON",
     exportPrivacy: "Exports only the completed collaboration response. It excludes your question, profile, provider settings, and hidden browser state.",
+    copyAnswer: "Copy answer",
+    copySources: "Copy sources",
+    copyAnswerSuccess: "Answer copied to clipboard.",
+    copySourcesSuccess: "Sources copied to clipboard.",
+    copyFailure: "Copy failed. Select and copy the text manually.",
     footer:
       "Prompts are untrusted input. Review your documents before publishing and never commit secrets.",
   },
@@ -131,6 +141,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "运行 ID",
     exportRun: "下载脱敏运行记录 JSON",
     exportPrivacy: "仅导出已完成的协作响应，不包含你的问题、个人资料、模型服务设置或浏览器隐藏状态。",
+    copyAnswer: "复制回答",
+    copySources: "复制来源",
+    copyAnswerSuccess: "回答已复制到剪贴板。",
+    copySourcesSuccess: "来源已复制到剪贴板。",
+    copyFailure: "复制失败，请手动选择并复制文本。",
     footer: "提示词是不可信输入。发布前请检查文档，切勿提交任何密钥。",
   },
   "zh-TW": {
@@ -169,6 +184,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "執行 ID",
     exportRun: "下載已清理的執行記錄 JSON",
     exportPrivacy: "只匯出已完成的協作回應，不包含你的問題、個人資料、模型服務設定或瀏覽器隱藏狀態。",
+    copyAnswer: "複製回答",
+    copySources: "複製來源",
+    copyAnswerSuccess: "回答已複製到剪貼簿。",
+    copySourcesSuccess: "來源已複製到剪貼簿。",
+    copyFailure: "複製失敗，請手動選取並複製文字。",
     footer: "提示詞是不受信任的輸入。發布前請檢查文件，切勿提交任何密鑰。",
   },
   ja: {
@@ -212,6 +232,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "実行 ID",
     exportRun: "サニタイズ済み実行 JSON をダウンロード",
     exportPrivacy: "完了した協働レスポンスのみを出力し、質問、プロフィール、プロバイダー設定、非表示のブラウザー状態は含みません。",
+    copyAnswer: "回答をコピー",
+    copySources: "ソースをコピー",
+    copyAnswerSuccess: "回答をクリップボードにコピーしました。",
+    copySourcesSuccess: "ソースをクリップボードにコピーしました。",
+    copyFailure: "コピーに失敗しました。テキストを選択して手動でコピーしてください。",
     footer:
       "プロンプトは信頼できない入力です。公開前に文書を確認し、秘密情報をコミットしないでください。",
   },
@@ -255,6 +280,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "실행 ID",
     exportRun: "정리된 실행 JSON 다운로드",
     exportPrivacy: "완료된 협업 응답만 내보내며 질문, 프로필, 공급자 설정 및 숨겨진 브라우저 상태는 제외합니다.",
+    copyAnswer: "답변 복사",
+    copySources: "출처 복사",
+    copyAnswerSuccess: "답변이 클립보드에 복사되었습니다.",
+    copySourcesSuccess: "출처가 클립보드에 복사되었습니다.",
+    copyFailure: "복사에 실패했습니다. 텍스트를 직접 선택해 복사하세요.",
     footer:
       "프롬프트는 신뢰할 수 없는 입력입니다. 게시 전에 문서를 검토하고 비밀 정보를 커밋하지 마세요.",
   },
@@ -299,6 +329,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "ID de ejecución",
     exportRun: "Descargar JSON de ejecución depurado",
     exportPrivacy: "Exporta solo la respuesta de colaboración terminada; excluye la pregunta, el perfil, la configuración del proveedor y el estado oculto del navegador.",
+    copyAnswer: "Copiar respuesta",
+    copySources: "Copiar fuentes",
+    copyAnswerSuccess: "Respuesta copiada al portapapeles.",
+    copySourcesSuccess: "Fuentes copiadas al portapapeles.",
+    copyFailure: "No se pudo copiar. Selecciona y copia el texto manualmente.",
     footer:
       "Los prompts son entradas no confiables. Revisa tus documentos antes de publicarlos y nunca confirmes secretos.",
   },
@@ -343,6 +378,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "ID d’exécution",
     exportRun: "Télécharger le JSON d’exécution épuré",
     exportPrivacy: "Exporte uniquement la réponse de collaboration terminée, sans la question, le profil, les réglages du fournisseur ni l’état caché du navigateur.",
+    copyAnswer: "Copier la réponse",
+    copySources: "Copier les sources",
+    copyAnswerSuccess: "Réponse copiée dans le presse-papiers.",
+    copySourcesSuccess: "Sources copiées dans le presse-papiers.",
+    copyFailure: "Échec de la copie. Sélectionnez et copiez le texte manuellement.",
     footer:
       "Les prompts sont des entrées non fiables. Vérifiez vos documents avant publication et ne validez jamais de secrets.",
   },
@@ -387,6 +427,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "Lauf-ID",
     exportRun: "Bereinigten Lauf als JSON herunterladen",
     exportPrivacy: "Exportiert nur die abgeschlossene Kollaborationsantwort; Frage, Profil, Anbieter-Einstellungen und verborgener Browserstatus werden ausgeschlossen.",
+    copyAnswer: "Antwort kopieren",
+    copySources: "Quellen kopieren",
+    copyAnswerSuccess: "Antwort in die Zwischenablage kopiert.",
+    copySourcesSuccess: "Quellen in die Zwischenablage kopiert.",
+    copyFailure: "Kopieren fehlgeschlagen. Text bitte manuell markieren und kopieren.",
     footer:
       "Prompts sind nicht vertrauenswürdige Eingaben. Prüfe Dokumente vor der Veröffentlichung und committe niemals Geheimnisse.",
   },
@@ -431,6 +476,11 @@ export const messages: Record<Locale, Messages> = {
     runId: "ID da execução",
     exportRun: "Baixar JSON sanitizado da execução",
     exportPrivacy: "Exporta somente a resposta de colaboração concluída; exclui a pergunta, o perfil, as configurações do provedor e o estado oculto do navegador.",
+    copyAnswer: "Copiar resposta",
+    copySources: "Copiar fontes",
+    copyAnswerSuccess: "Resposta copiada para a área de transferência.",
+    copySourcesSuccess: "Fontes copiadas para a área de transferência.",
+    copyFailure: "Falha ao copiar. Selecione e copie o texto manualmente.",
     footer:
       "Prompts são entradas não confiáveis. Revise os documentos antes de publicar e nunca faça commit de segredos.",
   },

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5,4 +5,5 @@
 .answer li > code,.run-id code,.stage-heading code,.workflow-trace dt,.workflow-trace dd{overflow-wrap:anywhere;word-break:break-word}
 
 .run-export{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin:14px 0 4px}.run-export button{width:auto;min-width:0;height:auto;padding:10px 14px}.run-export p{max-width:520px;margin:0;color:#5b6475;font-size:12px;line-height:1.5}@media(max-width:680px){.run-export{flex-direction:column}.run-export button{width:100%}}
+.copy-actions{display:flex;flex-wrap:wrap;gap:8px;margin:14px 0 0}.copy-actions button{width:auto;min-width:0;height:auto;padding:8px 12px;background:#fff;color:#172035;border:1px solid #d9deea;font-weight:700}.copy-actions button:hover{border-color:#5a63d8}.copy-status{margin:8px 0 0;color:#5b6475;font-size:12px}
 /* WCAG AA audit: muted #5b6475 is 5.96:1 on #fff and 5.56:1 on #f5f7fb. */


### PR DESCRIPTION
## Summary
- Add "Copy answer" and "Copy sources" buttons after a successful standard Q&A response
- Sources are copied as a deterministic plain-text list (`title — path`, one per line, preserving API order)
- Copy controls only render when the corresponding answer/source data exists
- Success and failure feedback is exposed via a `role="status"` (aria-live) region; clipboard failures show a safe, localized message with no browser internals exposed
- Added localized labels for all 9 locales in `frontend/src/i18n.ts`
- No new runtime dependency (uses the native Clipboard API)

Closes #74

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (32 passed, including new tests for answer copy, source copy, empty sources, and clipboard failure)
- [x] `npm run build`
- [x] Manually verified in a browser against the local backend: buttons render only when applicable, and the safe failure message displays correctly when the Clipboard API is unavailable/denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)