### PR TITLE
frontend: support privacy-safe workflow deep links

### DIFF
--- a/course/05-critic-observability/README.md
+++ b/course/05-critic-observability/README.md
@@ -113,7 +113,7 @@ cp .env.example .env
 docker compose up --build
 ```
 
-Open <http://localhost:5173> and select **Multi-agent lab**.
+Open <http://localhost:5173/?workflow=collaboration> (this deep-links straight to **Role-based multi-agent**).
 
 ### Step 2 — approved path
 
@@ -157,7 +157,8 @@ metrics contain only finite numbers or booleans.
 
 ### Step 5 — verified output path
 
-Select **Verified multi-agent** and repeat the grounded question. Confirm:
+Open <http://localhost:5173/?workflow=verified> (or select **Verified multi-agent**) and repeat the
+grounded question. Confirm:
 
 - the workflow identifier ends in `-verifier`;
 - the trace contains five ordered stages;

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -30,6 +30,7 @@ function routeFetch(chatResponse: object) {
 
 beforeEach(() => {
   window.localStorage.clear();
+  window.history.replaceState(null, "", "/");
   document.documentElement.lang = "en";
   document.title = "Agent-Me | An inspectable AI Twin";
   let description = document.querySelector<HTMLMetaElement>('meta[name="description"]');
@@ -236,6 +237,65 @@ it("uses a conservative disclosure when profile metadata is unavailable", () => 
       "External provider use is not confirmed. Questions may be forwarded to a configured provider.",
     ),
   ).toBeInTheDocument();
+});
+
+it("selects standard Q&A when no workflow parameter is present", () => {
+  vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => undefined)));
+
+  render(<App />);
+
+  expect(screen.getByRole("radio", { name: "Standard Q&A" })).toBeChecked();
+});
+
+it("selects the workflow from a direct link and falls back for invalid values", () => {
+  vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => undefined)));
+
+  window.history.replaceState(null, "", "/?workflow=collaboration");
+  const { unmount } = render(<App />);
+  expect(screen.getByRole("radio", { name: "Role-based multi-agent" })).toBeChecked();
+  unmount();
+
+  window.history.replaceState(null, "", "/?workflow=verified");
+  const verified = render(<App />);
+  expect(screen.getByRole("radio", { name: "Verified multi-agent" })).toBeChecked();
+  verified.unmount();
+
+  window.history.replaceState(null, "", "/?workflow=not-a-real-mode");
+  render(<App />);
+  expect(screen.getByRole("radio", { name: "Standard Q&A" })).toBeChecked();
+});
+
+it("updates the URL when the workflow changes without reloading and keeps unrelated params", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => undefined)));
+  window.history.replaceState(null, "", "/?foo=bar");
+
+  render(<App />);
+  await userEvent.click(screen.getByRole("radio", { name: "Verified multi-agent" }));
+
+  const params = new URLSearchParams(window.location.search);
+  expect(params.get("workflow")).toBe("verified");
+  expect(params.get("foo")).toBe("bar");
+  expect(window.location.search).not.toMatch(/question|answer|source|run_id/i);
+});
+
+it("updates the selected workflow on browser back and forward navigation", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => undefined)));
+
+  render(<App />);
+  await userEvent.click(screen.getByRole("radio", { name: "Role-based multi-agent" }));
+  expect(screen.getByRole("radio", { name: "Role-based multi-agent" })).toBeChecked();
+
+  window.history.replaceState(null, "", "/?workflow=verified");
+  window.dispatchEvent(new PopStateEvent("popstate"));
+  await waitFor(() =>
+    expect(screen.getByRole("radio", { name: "Verified multi-agent" })).toBeChecked(),
+  );
+
+  window.history.replaceState(null, "", "/");
+  window.dispatchEvent(new PopStateEvent("popstate"));
+  await waitFor(() =>
+    expect(screen.getByRole("radio", { name: "Standard Q&A" })).toBeChecked(),
+  );
 });
 
 it("runs the multi-agent lab and renders its ordered operational trace", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,10 +16,15 @@ import {
   supportedLocales,
 } from "./i18n";
 import { downloadCollaborationRun } from "./exportRun";
+import {
+  initialWorkflowMode,
+  readWorkflowMode,
+  workflowUrl,
+  WorkflowMode,
+} from "./workflowLink";
 import "./styles.css";
 
 const DEFAULT_MAX_QUESTION_CHARS = 8000;
-type WorkflowMode = "standard" | "collaboration" | "verified";
 
 function formatSourcesForCopy(sources: readonly { title: string; path: string }[]): string {
   return sources.map((source) => `${source.title} — ${source.path}`).join("\n");
@@ -32,7 +37,7 @@ export function App() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [profile, setProfile] = useState<ProfileResponse | null>(null);
-  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>("standard");
+  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>(initialWorkflowMode);
   const [copyStatus, setCopyStatus] = useState("");
   const text = messages[locale];
   const maxQuestionChars = profile?.max_question_chars ?? DEFAULT_MAX_QUESTION_CHARS;
@@ -45,6 +50,20 @@ export function App() {
   useEffect(() => {
     persistLocale(locale);
   }, [locale]);
+
+  useEffect(() => {
+    function onPopState() {
+      setWorkflowMode(readWorkflowMode(window.location.search));
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  function selectWorkflow(mode: WorkflowMode) {
+    setWorkflowMode(mode);
+    const url = workflowUrl(window.location, mode);
+    window.history.pushState({ workflow: mode }, "", url);
+  }
 
   useEffect(() => {
     const profileName = profile?.name.trim();
@@ -153,7 +172,7 @@ export function App() {
                 name="workflow"
                 value="standard"
                 checked={workflowMode === "standard"}
-                onChange={() => setWorkflowMode("standard")}
+                onChange={() => selectWorkflow("standard")}
                 disabled={loading}
               />
               {text.standardWorkflow}
@@ -164,7 +183,7 @@ export function App() {
                 name="workflow"
                 value="collaboration"
                 checked={workflowMode === "collaboration"}
-                onChange={() => setWorkflowMode("collaboration")}
+                onChange={() => selectWorkflow("collaboration")}
                 disabled={loading}
               />
               {text.collaborationWorkflow}
@@ -175,7 +194,7 @@ export function App() {
                 name="workflow"
                 value="verified"
                 checked={workflowMode === "verified"}
-                onChange={() => setWorkflowMode("verified")}
+                onChange={() => selectWorkflow("verified")}
                 disabled={loading}
               />
               {text.verifiedWorkflow}

--- a/frontend/src/workflowLink.test.ts
+++ b/frontend/src/workflowLink.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from "vitest";
+import { readWorkflowMode, workflowUrl } from "./workflowLink";
+
+it("reads a valid workflow value from a query string", () => {
+  expect(readWorkflowMode("?workflow=collaboration")).toBe("collaboration");
+  expect(readWorkflowMode("?workflow=verified")).toBe("verified");
+  expect(readWorkflowMode("?workflow=standard")).toBe("standard");
+});
+
+it("falls back to standard for an absent or invalid workflow value", () => {
+  expect(readWorkflowMode("")).toBe("standard");
+  expect(readWorkflowMode("?workflow=")).toBe("standard");
+  expect(readWorkflowMode("?workflow=not-a-real-mode")).toBe("standard");
+  expect(readWorkflowMode("?other=value")).toBe("standard");
+});
+
+it("sets the workflow parameter while preserving path, hash, and other params", () => {
+  const url = workflowUrl(
+    { pathname: "/demo", search: "?foo=bar&workflow=standard", hash: "#top" },
+    "verified",
+  );
+  expect(url).toBe("/demo?foo=bar&workflow=verified#top");
+});

--- a/frontend/src/workflowLink.ts
+++ b/frontend/src/workflowLink.ts
@@ -1,0 +1,24 @@
+export type WorkflowMode = "standard" | "collaboration" | "verified";
+
+const PARAM = "workflow";
+
+export function readWorkflowMode(search: string): WorkflowMode {
+  const value = new URLSearchParams(search).get(PARAM);
+  if (value === "standard" || value === "collaboration" || value === "verified") {
+    return value;
+  }
+  return "standard";
+}
+
+export function initialWorkflowMode(): WorkflowMode {
+  return readWorkflowMode(window.location.search);
+}
+
+export function workflowUrl(
+  location: Pick<Location, "pathname" | "search" | "hash">,
+  mode: WorkflowMode,
+): string {
+  const params = new URLSearchParams(location.search);
+  params.set(PARAM, mode);
+  return `${location.pathname}?${params.toString()}${location.hash}`;
+}


### PR DESCRIPTION
## Summary
- Sync only the workflow selection with a `?workflow=` query parameter: `standard`, `collaboration`, `verified`
- An absent or invalid value safely falls back to Standard Q&A
- Changing the radio control updates the URL via `history.pushState` (no reload), preserving any unrelated existing query parameters
- Browser Back/Forward updates the selected workflow via a `popstate` listener
- Locale preference is untouched and continues to use local storage
- No question, answer, source, trace, or run ID is ever placed in the URL or browser history
- No routing dependency added — plain `URLSearchParams`/`history` API in a small new `frontend/src/workflowLink.ts` module
- Updates the critic-observability course lesson to link directly to both collaboration modes (`?workflow=collaboration`, `?workflow=verified`)

Closes #78

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (36 passed — new coverage for direct links to all three modes, invalid-value fallback, URL updates on mode change with unrelated params preserved, and `popstate` back/forward)
- [x] `npm run build`
- [x] `python3 scripts/check_docs.py`
- [x] Manually verified in a browser: `?workflow=verified` deep link selects the right radio on load, clicking a radio updates the URL without a page reload, and browser Back restores the previous workflow selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)