### PR TITLE
backend: add server-generated request correlation IDs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from .collaboration import CollaborationOrchestrator
 from .config import Settings, get_settings
 from .knowledge import KnowledgeBase, KnowledgeLoadError
 from .provider import ProviderError, generate_answer
+from .request_id import RequestIDMiddleware
 from .request_limits import RequestBodyLimitMiddleware
 from .schemas import (
     ChatRequest,
@@ -37,7 +38,9 @@ app.add_middleware(
     allow_credentials=False,
     allow_methods=["GET", "POST"],
     allow_headers=["Content-Type"],
+    expose_headers=["X-Request-ID"],
 )
+app.add_middleware(RequestIDMiddleware)
 
 
 _PROVIDER_ERROR_MESSAGES = {

--- a/backend/app/request_id.py
+++ b/backend/app/request_id.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import secrets
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+REQUEST_ID_HEADER = b"x-request-id"
+REQUEST_ID_PREFIX = "req_"
+
+
+def generate_request_id() -> str:
+    """Return a fresh, collision-resistant, server-controlled request ID."""
+    return f"{REQUEST_ID_PREFIX}{secrets.token_hex(16)}"
+
+
+class RequestIDMiddleware:
+    """Attach a server-generated `X-Request-ID` to every HTTP response.
+
+    Any client-supplied `X-Request-ID` request header is ignored: it is
+    never read, trusted, or reflected back.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = generate_request_id()
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers.append((REQUEST_ID_HEADER, request_id.encode("ascii")))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_request_id)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,3 +1,4 @@
+import re
 import threading
 from pathlib import Path
 
@@ -359,3 +360,70 @@ async def test_incomplete_provider_configuration_fails_explicitly(
         "detail": "Provider configuration is incomplete.",
         "code": "provider_configuration_incomplete",
     }
+
+
+REQUEST_ID_PATTERN = re.compile(r"^req_[0-9a-f]{32}$")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("get", "/health", {}),
+        ("get", "/api/v1/profile", {}),
+        ("post", "/api/v1/chat", {"json": {"question": "prefers Python tools?"}}),
+    ],
+)
+async def test_request_id_header_present_on_success(
+    client: httpx.AsyncClient, method: str, path: str, kwargs: dict
+) -> None:
+    response = await client.request(method, path, **kwargs)
+
+    assert response.status_code == 200
+    assert REQUEST_ID_PATTERN.match(response.headers["x-request-id"])
+
+
+@pytest.mark.anyio
+async def test_request_id_header_present_on_handled_errors(client: httpx.AsyncClient) -> None:
+    validation_error = await client.post(
+        "/api/v1/collaborate",
+        json={"question": "prefers Python tools?", "workflow": "attacker-controlled"},
+    )
+
+    settings = get_settings()
+    original = settings.max_question_chars
+    settings.max_question_chars = 5
+    try:
+        semantic_limit_error = await client.post("/api/v1/chat", json={"question": "123456"})
+    finally:
+        settings.max_question_chars = original
+
+    assert validation_error.status_code == 422
+    assert REQUEST_ID_PATTERN.match(validation_error.headers["x-request-id"])
+    assert semantic_limit_error.status_code == 413
+    assert REQUEST_ID_PATTERN.match(semantic_limit_error.headers["x-request-id"])
+
+
+@pytest.mark.anyio
+async def test_request_id_is_fresh_and_ignores_client_supplied_value(
+    client: httpx.AsyncClient,
+) -> None:
+    spoofed = "req_" + "a" * 32
+    first = await client.get("/health", headers={"X-Request-ID": spoofed})
+    second = await client.get("/health", headers={"X-Request-ID": spoofed})
+
+    assert first.headers["x-request-id"] != spoofed
+    assert second.headers["x-request-id"] != spoofed
+    assert first.headers["x-request-id"] != second.headers["x-request-id"]
+
+
+@pytest.mark.anyio
+async def test_request_id_header_is_exposed_to_allowed_browser_origins(
+    client: httpx.AsyncClient,
+) -> None:
+    origin = get_settings().allowed_origins[0]
+    response = await client.get("/health", headers={"Origin": origin})
+
+    exposed = response.headers.get("access-control-expose-headers", "")
+    assert "X-Request-ID" in exposed
+    assert response.headers["access-control-allow-origin"] == origin

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,15 @@
 # API reference
 
+## Request correlation
+
+Every HTTP response includes a server-generated `X-Request-ID` header, for example
+`req_0123456789abcdef0123456789abcdef`. It is created fresh per request from a
+collision-resistant source and is present on successful responses and on responses handled by an
+application exception handler (validation, size-limit, provider, and knowledge-base errors). Any
+`X-Request-ID` header sent by the client is ignored — it is never read, trusted, or reflected back.
+The header contains no user input, prompt content, or knowledge-base data; it exists only to let a
+learner correlate one browser request with the corresponding server-side response or log line.
+
 ## `GET /health`
 
 Liveness check. Returns `{ "status": "healthy" }`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,13 @@ abstractions. See [Trust, Data Flow, and Deployment Boundaries](TRUST.md) for th
    recent history, and retrieved context will be forwarded to the configured provider.
 4. Secrets are loaded from environment variables and excluded from source control.
 
+## Observability
+
+An outer ASGI middleware (`RequestIDMiddleware`) attaches a fresh, server-generated `X-Request-ID`
+header to every HTTP response, including those produced by application exception handlers. It never
+reads or reflects a client-supplied `X-Request-ID`, and the value carries no user input, prompt
+content, or knowledge-base data — see [`docs/API.md`](API.md#request-correlation).
+
 ## Request path
 
 `POST /api/v1/chat` validates the body, enforces the configured question limit, removes a small


### PR DESCRIPTION
## Summary
- Adds `RequestIDMiddleware` (`backend/app/request_id.py`), an outer ASGI middleware that attaches a fresh `X-Request-ID: req_<32 hex chars>` header to every HTTP response
- IDs are generated server-side via `secrets.token_hex(16)` (collision-resistant), with a documented stable `req_` prefix
- Any client-supplied `X-Request-ID` request header is never read, trusted, or reflected
- The header is present on successful responses and on responses produced by application exception handlers (validation, size-limit, provider, knowledge-base errors)
- CORS `expose_headers` now includes `X-Request-ID` for allowed browser origins, without broadening allowed origins, methods, or request headers
- No existing response schema changes — fully backward compatible
- Documents the header and its privacy boundary in `docs/API.md` and `docs/ARCHITECTURE.md`

Closes #77

## Test plan
- [x] `ruff check app tests`
- [x] `ruff format --check app tests`
- [x] `pytest backend/tests` (69 passed, 1 skipped) — new coverage for header format, uniqueness, presence on success and on handled errors (422 validation, 413 semantic limit), ignoring a spoofed client-supplied value, and CORS exposure
- [x] `npm test` in `frontend` (no regressions — response shapes unchanged)
- [x] `python3 scripts/check_docs.py`
- [x] Manually verified with `curl`: fresh unique IDs per request, a spoofed client `X-Request-ID` is ignored, and `Access-Control-Expose-Headers: X-Request-ID` is present for an allowed `Origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)