### PR TITLE
fix(knowledge): bound aggregate corpus loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,10 @@ APP_DESCRIPTION=Build, inspect, and evaluate auditable role-based multi-agent RA
 KNOWLEDGE_DIR=knowledge
 MAX_QUESTION_CHARS=8000
 MAX_CONTEXT_CHARS=12000
+# Per-file limit, followed by whole-corpus document-count and byte limits.
 MAX_DOCUMENT_BYTES=1000000
+MAX_KNOWLEDGE_DOCUMENTS=256
+MAX_KNOWLEDGE_BYTES=16000000
 MAX_HISTORY_CHARS=24000
 MAX_ANSWER_CHARS=50000
 # Complete decoded upstream HTTP response limit; enforced before JSON parsing.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,6 +16,8 @@ class Settings(BaseSettings):
     max_question_chars: int = Field(default=8_000, ge=1, le=100_000)
     max_context_chars: int = Field(default=12_000, ge=1, le=100_000)
     max_document_bytes: int = Field(default=1_000_000, ge=1, le=50_000_000)
+    max_knowledge_documents: int = Field(default=256, ge=1, le=10_000)
+    max_knowledge_bytes: int = Field(default=16_000_000, ge=1, le=1_000_000_000)
     max_history_chars: int = Field(default=24_000, ge=1, le=200_000)
     max_answer_chars: int = Field(default=50_000, ge=1, le=200_000)
     max_provider_response_bytes: int = Field(default=2_000_000, ge=1_024, le=50_000_000)

--- a/backend/app/knowledge.py
+++ b/backend/app/knowledge.py
@@ -110,50 +110,71 @@ def _content_chunks(text: str) -> list[str]:
 
 
 class KnowledgeBase:
-    def __init__(self, directory: str, *, max_document_bytes: int = 1_000_000) -> None:
+    def __init__(
+        self,
+        directory: str,
+        *,
+        max_document_bytes: int = 1_000_000,
+        max_documents: int = 256,
+        max_corpus_bytes: int = 16_000_000,
+    ) -> None:
+        if max_document_bytes < 1:
+            raise ValueError("max_document_bytes must be positive")
+        if max_documents < 1:
+            raise ValueError("max_documents must be positive")
+        if max_corpus_bytes < 1:
+            raise ValueError("max_corpus_bytes must be positive")
         self.directory = Path(directory)
         self.max_document_bytes = max_document_bytes
+        self.max_documents = max_documents
+        self.max_corpus_bytes = max_corpus_bytes
         self._cache_lock = RLock()
         self._cached_root: Path | None = None
         self._cached_signature: tuple[tuple[str, int, int, int], ...] | None = None
         self._cached_documents: tuple[Document, ...] = ()
 
     def _files(self, root: Path) -> list[_KnowledgeFile]:
+        result: list[_KnowledgeFile] = []
+        total_bytes = 0
         try:
-            paths = sorted(self.directory.rglob("*.md"))
+            paths = self.directory.rglob("*.md")
+            for path in paths:
+                if path.is_symlink():
+                    raise KnowledgeLoadError("knowledge_symlink_rejected")
+                try:
+                    resolved = path.resolve(strict=True)
+                    relative_path = resolved.relative_to(root).as_posix()
+                except (OSError, ValueError) as error:
+                    raise KnowledgeLoadError("knowledge_path_rejected") from error
+                if not resolved.is_file():
+                    continue
+                try:
+                    stat = resolved.stat()
+                    if stat.st_size > self.max_document_bytes:
+                        raise KnowledgeLoadError("knowledge_document_too_large")
+                except KnowledgeLoadError:
+                    raise
+                except OSError as error:
+                    raise KnowledgeLoadError("knowledge_document_unreadable") from error
+
+                if len(result) >= self.max_documents:
+                    raise KnowledgeLoadError("knowledge_document_count_exceeded")
+                total_bytes += stat.st_size
+                if total_bytes > self.max_corpus_bytes:
+                    raise KnowledgeLoadError("knowledge_corpus_too_large")
+
+                result.append(
+                    _KnowledgeFile(
+                        resolved=resolved,
+                        relative_path=relative_path,
+                        size=stat.st_size,
+                        modified_ns=stat.st_mtime_ns,
+                        changed_ns=stat.st_ctime_ns,
+                    )
+                )
         except OSError as error:
             raise KnowledgeLoadError("knowledge_directory_unavailable") from error
-
-        result: list[_KnowledgeFile] = []
-        for path in paths:
-            if path.is_symlink():
-                raise KnowledgeLoadError("knowledge_symlink_rejected")
-            try:
-                resolved = path.resolve(strict=True)
-                resolved.relative_to(root)
-            except (OSError, ValueError) as error:
-                raise KnowledgeLoadError("knowledge_path_rejected") from error
-            if not resolved.is_file():
-                continue
-            try:
-                stat = resolved.stat()
-                if stat.st_size > self.max_document_bytes:
-                    raise KnowledgeLoadError("knowledge_document_too_large")
-            except KnowledgeLoadError:
-                raise
-            except OSError as error:
-                raise KnowledgeLoadError("knowledge_document_unreadable") from error
-
-            result.append(
-                _KnowledgeFile(
-                    resolved=resolved,
-                    relative_path=path.relative_to(self.directory).as_posix(),
-                    size=stat.st_size,
-                    modified_ns=stat.st_mtime_ns,
-                    changed_ns=stat.st_ctime_ns,
-                )
-            )
-        return result
+        return sorted(result, key=lambda item: item.relative_path)
 
     @staticmethod
     def _signature(
@@ -165,12 +186,18 @@ class KnowledgeBase:
 
     def _read(self, files: list[_KnowledgeFile]) -> list[Document]:
         result: list[Document] = []
+        total_bytes = 0
         for item in files:
             try:
+                remaining_corpus_bytes = self.max_corpus_bytes - total_bytes
+                read_limit = min(self.max_document_bytes, remaining_corpus_bytes)
                 with item.resolved.open("rb") as source:
-                    raw = source.read(self.max_document_bytes + 1)
+                    raw = source.read(read_limit + 1)
                 if len(raw) > self.max_document_bytes:
                     raise KnowledgeLoadError("knowledge_document_too_large")
+                total_bytes += len(raw)
+                if total_bytes > self.max_corpus_bytes:
+                    raise KnowledgeLoadError("knowledge_corpus_too_large")
                 text = raw.decode("utf-8")
             except KnowledgeLoadError:
                 raise

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,8 +64,27 @@ class SemanticLimitError(Exception):
 
 
 @lru_cache(maxsize=16)
-def _knowledge_base(directory: str, max_document_bytes: int) -> KnowledgeBase:
-    return KnowledgeBase(directory, max_document_bytes=max_document_bytes)
+def _knowledge_base(
+    directory: str,
+    max_document_bytes: int,
+    max_knowledge_documents: int,
+    max_knowledge_bytes: int,
+) -> KnowledgeBase:
+    return KnowledgeBase(
+        directory,
+        max_document_bytes=max_document_bytes,
+        max_documents=max_knowledge_documents,
+        max_corpus_bytes=max_knowledge_bytes,
+    )
+
+
+def _configured_knowledge_base(config: Settings) -> KnowledgeBase:
+    return _knowledge_base(
+        config.knowledge_dir,
+        config.max_document_bytes,
+        config.max_knowledge_documents,
+        config.max_knowledge_bytes,
+    )
 
 
 @app.exception_handler(SemanticLimitError)
@@ -109,7 +128,7 @@ async def health() -> dict[str, str]:
 async def ready(
     config: Settings = Depends(get_settings),
 ) -> JSONResponse:
-    knowledge = _knowledge_base(config.knowledge_dir, config.max_document_bytes)
+    knowledge = _configured_knowledge_base(config)
     documents = await run_in_threadpool(knowledge.documents)
     is_ready = bool(documents) and config.provider_state != "misconfigured"
     content: dict[str, object] = {
@@ -142,7 +161,7 @@ async def chat(payload: ChatRequest, config: Settings = Depends(get_settings)) -
             code="history_too_large",
             detail="history exceeds configured limit",
         )
-    knowledge = _knowledge_base(config.knowledge_dir, config.max_document_bytes)
+    knowledge = _configured_knowledge_base(config)
     matches = await run_in_threadpool(knowledge.search, payload.question)
     answer, mode = await generate_answer(
         question=payload.question,
@@ -175,7 +194,7 @@ async def collaborate(
             code="question_too_large",
             detail="question exceeds configured limit",
         )
-    knowledge = _knowledge_base(config.knowledge_dir, config.max_document_bytes)
+    knowledge = _configured_knowledge_base(config)
     result = await run_in_threadpool(
         CollaborationOrchestrator(retriever=knowledge).run,
         question=payload.question,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -140,6 +140,79 @@ async def test_unsafe_knowledge_returns_safe_service_error(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("GET", "/ready", None),
+        ("POST", "/api/v1/chat", {"question": "Python?"}),
+        ("POST", "/api/v1/collaborate", {"question": "Python?"}),
+    ],
+)
+async def test_aggregate_knowledge_limit_fails_closed_without_path_disclosure(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+    method: str,
+    path: str,
+    payload: dict[str, str] | None,
+) -> None:
+    (tmp_path / "private-corpus-name.md").write_text("private", encoding="utf-8")
+    settings = get_settings()
+    original = settings.max_knowledge_documents
+    settings.max_knowledge_documents = 1
+    try:
+        response = await client.request(method, path, json=payload)
+    finally:
+        settings.max_knowledge_documents = original
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": "Knowledge base is temporarily unavailable.",
+        "code": "knowledge_document_count_exceeded",
+    }
+    assert "private-corpus-name" not in response.text
+    assert str(tmp_path) not in response.text
+
+
+@pytest.mark.anyio
+async def test_ready_enforces_aggregate_knowledge_bytes(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+) -> None:
+    settings = get_settings()
+    original = settings.max_knowledge_bytes
+    profile_size = (tmp_path / "profile.md").stat().st_size
+    settings.max_knowledge_bytes = profile_size - 1
+    try:
+        response = await client.get("/ready")
+    finally:
+        settings.max_knowledge_bytes = original
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": "Knowledge base is temporarily unavailable.",
+        "code": "knowledge_corpus_too_large",
+    }
+    assert str(tmp_path) not in response.text
+
+
+def test_knowledge_base_cache_separates_every_limit_configuration(tmp_path: Path) -> None:
+    main_module._knowledge_base.cache_clear()
+    try:
+        baseline = main_module._knowledge_base(str(tmp_path), 100, 1, 100)
+        same = main_module._knowledge_base(str(tmp_path), 100, 1, 100)
+        different_file_limit = main_module._knowledge_base(str(tmp_path), 101, 1, 100)
+        different_count_limit = main_module._knowledge_base(str(tmp_path), 100, 2, 100)
+        different_corpus_limit = main_module._knowledge_base(str(tmp_path), 100, 1, 101)
+    finally:
+        main_module._knowledge_base.cache_clear()
+
+    assert baseline is same
+    assert baseline is not different_file_limit
+    assert baseline is not different_count_limit
+    assert baseline is not different_corpus_limit
+
+
+@pytest.mark.anyio
 async def test_grounded_extractive_answer(client: httpx.AsyncClient) -> None:
     response = await client.post("/api/v1/chat", json={"question": "prefers Python tools?"})
     assert response.status_code == 200

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,25 @@
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+def test_knowledge_aggregate_limit_defaults() -> None:
+    settings = Settings(_env_file=None)
+
+    assert settings.max_knowledge_documents == 256
+    assert settings.max_knowledge_bytes == 16_000_000
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_knowledge_documents", 0),
+        ("max_knowledge_documents", 10_001),
+        ("max_knowledge_bytes", 0),
+        ("max_knowledge_bytes", 1_000_000_001),
+    ],
+)
+def test_knowledge_aggregate_limits_are_bounded(field: str, value: int) -> None:
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, **{field: value})

--- a/backend/tests/test_knowledge.py
+++ b/backend/tests/test_knowledge.py
@@ -29,6 +29,92 @@ def test_oversized_document_is_rejected_without_exposing_its_path(tmp_path: Path
     assert "private-name" not in str(captured.value)
 
 
+def test_document_count_limit_is_inclusive_and_counts_nested_files(tmp_path: Path) -> None:
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (tmp_path / "a.md").write_text("a", encoding="utf-8")
+    (nested / "b.md").write_text("b", encoding="utf-8")
+
+    documents = KnowledgeBase(str(tmp_path), max_documents=2).documents()
+
+    assert [document.path for document in documents] == ["a.md", "nested/b.md"]
+    with pytest.raises(KnowledgeLoadError) as captured:
+        KnowledgeBase(str(tmp_path), max_documents=1).documents()
+    assert captured.value.code == "knowledge_document_count_exceeded"
+    assert str(tmp_path) not in str(captured.value)
+
+
+def test_aggregate_byte_limit_is_inclusive_and_rejects_one_byte_over(tmp_path: Path) -> None:
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (tmp_path / "a.md").write_text("1234", encoding="utf-8")
+    (nested / "b.md").write_text("56789", encoding="utf-8")
+
+    documents = KnowledgeBase(str(tmp_path), max_corpus_bytes=9).documents()
+
+    assert [document.path for document in documents] == ["a.md", "nested/b.md"]
+    with pytest.raises(KnowledgeLoadError) as captured:
+        KnowledgeBase(str(tmp_path), max_corpus_bytes=8).documents()
+    assert captured.value.code == "knowledge_corpus_too_large"
+    assert str(tmp_path) not in str(captured.value)
+
+
+@pytest.mark.parametrize(
+    ("limits", "expected_code"),
+    [
+        ({"max_documents": 1}, "knowledge_document_count_exceeded"),
+        ({"max_corpus_bytes": 3}, "knowledge_corpus_too_large"),
+    ],
+)
+def test_aggregate_metadata_rejection_happens_before_any_document_is_opened(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    limits: dict[str, int],
+    expected_code: str,
+) -> None:
+    (tmp_path / "a.md").write_text("12", encoding="utf-8")
+    (tmp_path / "b.md").write_text("34", encoding="utf-8")
+
+    def unexpected_open(*_: object, **__: object) -> None:
+        raise AssertionError("document content was opened after metadata rejection")
+
+    monkeypatch.setattr(Path, "open", unexpected_open)
+    with pytest.raises(KnowledgeLoadError) as captured:
+        KnowledgeBase(str(tmp_path), **limits).documents()
+    assert captured.value.code == expected_code
+
+
+def test_aggregate_read_limit_handles_a_file_growing_after_metadata_scan(tmp_path: Path) -> None:
+    profile = tmp_path / "profile.md"
+    profile.write_text("12", encoding="utf-8")
+    knowledge = KnowledgeBase(str(tmp_path), max_corpus_bytes=3)
+    root = tmp_path.resolve(strict=True)
+    files = knowledge._files(root)
+
+    profile.write_text("1234", encoding="utf-8")
+
+    with pytest.raises(KnowledgeLoadError) as captured:
+        knowledge._read(files)
+    assert captured.value.code == "knowledge_corpus_too_large"
+
+
+@pytest.mark.parametrize(
+    ("limits", "message"),
+    [
+        ({"max_document_bytes": 0}, "max_document_bytes"),
+        ({"max_documents": 0}, "max_documents"),
+        ({"max_corpus_bytes": 0}, "max_corpus_bytes"),
+    ],
+)
+def test_direct_loader_limits_must_be_positive(
+    tmp_path: Path,
+    limits: dict[str, int],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        KnowledgeBase(str(tmp_path), **limits)
+
+
 def test_symbolic_linked_document_is_rejected(tmp_path: Path) -> None:
     outside = tmp_path.parent / "outside-private.md"
     outside.write_text("private", encoding="utf-8")
@@ -170,6 +256,32 @@ def test_documents_cache_is_reused_and_invalidated_by_corpus_changes(
 
     profile.unlink()
     assert [document.path for document in knowledge.documents()] == ["extra.md"]
+
+
+def test_cache_refresh_fails_closed_and_recovers_when_aggregate_limits_change_corpus(
+    tmp_path: Path,
+) -> None:
+    profile = tmp_path / "profile.md"
+    profile.write_text("1234", encoding="utf-8")
+    knowledge = KnowledgeBase(str(tmp_path), max_documents=1, max_corpus_bytes=4)
+    assert [document.path for document in knowledge.documents()] == ["profile.md"]
+
+    extra = tmp_path / "extra.md"
+    extra.write_text("", encoding="utf-8")
+    with pytest.raises(KnowledgeLoadError) as count_error:
+        knowledge.documents()
+    assert count_error.value.code == "knowledge_document_count_exceeded"
+
+    extra.unlink()
+    assert [document.path for document in knowledge.documents()] == ["profile.md"]
+
+    profile.write_text("12345", encoding="utf-8")
+    with pytest.raises(KnowledgeLoadError) as byte_error:
+        knowledge.documents()
+    assert byte_error.value.code == "knowledge_corpus_too_large"
+
+    profile.write_text("12", encoding="utf-8")
+    assert knowledge.documents()[0].text == "12"
 
 
 def test_concurrent_document_reads_publish_one_consistent_cache(tmp_path: Path) -> None:

--- a/course/02-retrieval/README.md
+++ b/course/02-retrieval/README.md
@@ -29,7 +29,7 @@ By the end, you can:
 Agent-Me uses a deliberately small lexical baseline:
 
 1. recursively find Markdown files under `KNOWLEDGE_DIR`;
-2. reject symlinks, paths outside the root, invalid UTF-8, and oversized files;
+2. reject symlinks, paths outside the root, invalid UTF-8, oversized files, or an oversized corpus;
 3. turn each nonempty Markdown block into a candidate chunk;
 4. retain ATX heading text while stripping heading markers;
 5. apply Unicode NFKC normalization and case folding, then tokenize Unicode words and individual
@@ -65,9 +65,10 @@ Its simplicity is not a claim of state-of-the-art quality.
 ## Runtime I/O and cache boundary
 
 The API reuses immutable parsed `Document` values only while a filesystem signature is unchanged.
-It still scans metadata and repeats the root, symlink, file-type, and size checks on every access;
-adding, editing, or removing a Markdown file invalidates the cached corpus. API routes run the
-synchronous scan/search in a worker thread so it does not block FastAPI's async event loop.
+It still scans metadata and repeats the root, symlink, file-type, per-file size, document-count, and
+aggregate-byte checks on every access; adding, editing, or removing a Markdown file invalidates the
+cached corpus. API routes run the synchronous scan/search in a worker thread so it does not block
+FastAPI's async event loop.
 
 This is a process-local performance cache, not storage or a source of truth. A restart begins with
 an empty cache, and the configured filesystem remains authoritative.
@@ -192,8 +193,15 @@ The loader rejects several unsafe or unreliable cases:
 - symbolic links that could escape the intended knowledge root;
 - resolved paths outside that root;
 - files above `MAX_DOCUMENT_BYTES`;
+- more than `MAX_KNOWLEDGE_DOCUMENTS` Markdown files;
+- a combined Markdown size above `MAX_KNOWLEDGE_BYTES`;
 - unreadable or invalid UTF-8 content;
 - a configured path that is not a directory.
+
+The first size limit is per file; the latter two bound the whole discovered snapshot. Count and
+aggregate-byte failures are determined from metadata before any document body is parsed. The loader
+fails the entire snapshot instead of silently skipping files, and readiness, chat, collaboration,
+and cache refreshes all use the same limits.
 
 These controls address filesystem trust. They do not make the Markdown factually trustworthy.
 Corpus review and authorization are separate responsibilities.

--- a/course/07-production-capstone/README.md
+++ b/course/07-production-capstone/README.md
@@ -31,7 +31,7 @@ By the end, you can:
 
 The baseline implements and tests:
 
-- strict request models and body-size limits;
+- strict request models plus request-body, per-file, document-count, and aggregate-corpus limits;
 - deterministic local retrieval and role order;
 - server-controlled run IDs;
 - frozen internal handoff artifacts;
@@ -207,7 +207,8 @@ make build
 ### Security and privacy
 
 - Who can read knowledge, traces, and outputs?
-- Are request bodies and files size-limited before expensive processing?
+- Are request bodies, individual files, document counts, and aggregate corpus bytes bounded before
+  expensive processing?
 - Are secrets excluded from Git, responses, and logs?
 - Are retention and deletion implemented and tested?
 

--- a/course/translations/zh-CN/02-retrieval/README.md
+++ b/course/translations/zh-CN/02-retrieval/README.md
@@ -24,7 +24,7 @@
 Agent-Me 使用一个刻意简单的词法基线：
 
 1. 在 `KNOWLEDGE_DIR` 递归寻找 Markdown；
-2. 拒绝 symlink、越界路径、非法 UTF-8 和过大文件；
+2. 拒绝 symlink、越界路径、非法 UTF-8、过大文件或过大的语料库；
 3. 把每个非空 Markdown block 变成候选 chunk；
 4. 保留 ATX 标题文字但移除 `#`；
 5. 先做 Unicode NFKC 规范化与大小写折叠，再将 Unicode 单词和每个汉字分词；
@@ -41,8 +41,9 @@ Agent-Me 使用一个刻意简单的词法基线：
 ## 运行时 I/O 与缓存边界
 
 只有文件系统签名不变时，API 才会复用不可变的 `Document` 解析结果。每次访问仍会扫描元数据，
-并重新执行根目录、symlink、文件类型和大小检查；新增、修改或删除 Markdown 都会让缓存失效。
-API route 会在线程池运行同步扫描与检索，避免阻塞 FastAPI 的 async event loop。
+并重新执行根目录、symlink、文件类型、单文件大小、文档数量和语料库总字节数检查；新增、修改或
+删除 Markdown 都会让缓存失效。API route 会在线程池运行同步扫描与检索，避免阻塞 FastAPI 的
+async event loop。
 
 这是进程内性能缓存，不是存储或事实来源。进程重启后缓存为空，配置的文件系统始终是权威来源。
 
@@ -118,7 +119,13 @@ PY
 
 ### 文件安全边界
 
-加载器拒绝 symlink、越出根目录的解析路径、超大文件、非法 UTF-8、非目录配置。这些保护文件系统边界，不保证 Markdown 事实可信。内容审核和授权是另一层责任。
+`MAX_DOCUMENT_BYTES` 限制每个文件；`MAX_KNOWLEDGE_DOCUMENTS` 限制一个快照中的 Markdown
+文档数；`MAX_KNOWLEDGE_BYTES` 限制这些文档的总字节数。加载器先从元数据检查数量和总大小，
+超过边界时不会继续读取文档正文，也不会静默跳过文件。readiness、chat、collaboration 与缓存
+刷新共用这些规则。
+
+加载器还拒绝 symlink、越出根目录的解析路径、非法 UTF-8 和非目录配置。这些控制保护文件系统
+与资源边界，但不保证 Markdown 事实可信。内容审核和授权是另一层责任。
 
 ## 练习
 

--- a/course/translations/zh-CN/07-production-capstone/README.md
+++ b/course/translations/zh-CN/07-production-capstone/README.md
@@ -24,7 +24,9 @@
 
 ## 原理：当前保证与缺失保证
 
-当前已实现并测试：严格 request/body 限制、确定性本地检索与角色顺序、服务端 run ID、frozen 工件、批准/阻断路径、可选的 fail-closed 引用不变量验证、严格浏览器解析、安全纯文本、不持久化问题/trace、CI/评估/容器 smoke。
+当前已实现并测试：严格 request model、request body、单文件、文档数量与语料库总字节数限制，
+以及确定性本地检索与角色顺序、服务端 run ID、frozen 工件、批准/阻断路径、可选的 fail-closed
+引用不变量验证、严格浏览器解析、安全纯文本、不持久化问题/trace、CI/评估/容器 smoke。
 
 当前没有：重启后持久状态、多 Worker 协调、exactly-once、provider 冗余/预算、认证授权/tenant 隔离、加密 trace/retention job、生产规模语义检索、形式化忠实度、SLO 与事故响应。
 
@@ -119,7 +121,8 @@ make build
 
 ### 安全/隐私
 
-谁能读 knowledge/trace/output？昂贵处理前是否限制 body/file？密钥是否不进入 Git/响应/日志？保留与删除是否实现并测试？
+谁能读 knowledge/trace/output？昂贵处理前是否限制 request body、单文件、文档数量和语料库总字节数？
+密钥是否不进入 Git/响应/日志？保留与删除是否实现并测试？
 
 ### 可观测性与评估
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -32,7 +32,11 @@ Request fields:
 - `question`: required nonblank string, capped by `MAX_QUESTION_CHARS`.
 - `history`: optional array of up to 20 `{role, content}` items. Roles are `user` or `assistant`; total content is capped by `MAX_HISTORY_CHARS`.
 
-Unknown fields, invalid roles, blank content, and oversized fields are rejected. Unsafe symbolic links, unreadable Markdown, or documents larger than `MAX_DOCUMENT_BYTES` make readiness and chat return a safe `503` without exposing a private path. The response includes `answer`, `mode`, and grounding `sources`.
+Unknown fields, invalid roles, blank content, and oversized fields are rejected. Unsafe symbolic
+links, unreadable Markdown, a file larger than `MAX_DOCUMENT_BYTES`, more than
+`MAX_KNOWLEDGE_DOCUMENTS` Markdown files, or a corpus larger than `MAX_KNOWLEDGE_BYTES` make
+readiness, chat, and collaboration return a safe `503` without exposing private paths or filenames.
+The response includes `answer`, `mode`, and grounding `sources`.
 
 The application rejects HTTP request bodies larger than `MAX_REQUEST_BODY_BYTES` with `413`, before JSON parsing. This applies both when `Content-Length` is present and when a body is streamed without it.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,9 @@ abstractions. See [Trust, Data Flow, and Deployment Boundaries](TRUST.md) for th
 ## Trust boundaries
 
 1. Browser questions are untrusted and validated by Pydantic.
-2. Knowledge files are operator-controlled but bounded by the configured root and file-size limit; symbolic links are rejected and content is rendered as plain text.
+2. Knowledge files are operator-controlled but bounded by the configured root, per-file size,
+   document count, and aggregate corpus size; symbolic links are rejected and content is rendered as
+   plain text.
 3. Provider output is untrusted and rendered as text, never inserted as HTML. Before submission,
    the browser uses the public `external_provider_enabled` flag to disclose whether the question,
    recent history, and retrieved context will be forwarded to the configured provider.
@@ -33,9 +35,10 @@ numbers remain word tokens, while Han characters remain individual tokens to pre
 reference implementation's deterministic CJK behavior. Retrieval scoring and collaboration coverage metrics share
 this implementation so canonically equivalent text is treated consistently.
 
-The API reuses `KnowledgeBase` instances for identical roots and size limits. Every access still
-rescans bounded file metadata and re-enforces the root, symlink, file-type, and size rules; unchanged
-signatures reuse immutable parsed documents, while add/edit/remove operations invalidate the cache.
+The API reuses `KnowledgeBase` instances only for identical roots and identical per-file,
+document-count, and aggregate-byte limits. Every access still rescans bounded file metadata and
+re-enforces the root, symlink, file-type, and size rules; unchanged signatures reuse immutable parsed
+documents, while add/edit/remove operations invalidate the cache.
 Readiness, search, and the local collaboration run execute through Starlette's worker thread pool so
 synchronous filesystem work does not block the async event loop. The cache is process-local only;
 the filesystem remains authoritative after edits and process restarts.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,6 +11,12 @@ a reproducible local reference environment, not a production-ready hosted platfo
 6. Keep provider credentials in a secret manager and rotate them regularly.
 7. Monitor `/health` and `/ready` without logging request bodies.
 
+`MAX_DOCUMENT_BYTES` limits each Markdown file. `MAX_KNOWLEDGE_DOCUMENTS` and
+`MAX_KNOWLEDGE_BYTES` independently limit the document count and aggregate bytes in one corpus
+snapshot. The defaults are 1 MB per file, 256 documents, and 16 MB total. Tune them to the reviewed
+corpus and available memory rather than disabling the bounds; a limit violation fails readiness,
+chat, and collaboration closed with a path-free `503`.
+
 The included Compose file is intended for local evaluation. It binds both services to loopback, runs the API with all Linux capabilities dropped, runs both services with read-only root filesystems and `no-new-privileges`, and gives Nginx only the capabilities and temporary filesystems it needs. Set `API_BIND` or `WEB_BIND` only when you intentionally need a non-loopback development listener.
 
 The web image sends browser requests to same-origin `/api` by default. Its Nginx configuration

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -22,9 +22,10 @@ With `LLM_BASE_URL`, `LLM_API_KEY`, and `LLM_MODEL` all unset:
 - questions, chat history, retrieved excerpts, and traces are not sent to a model provider; and
 - no paid model API is required.
 
-The service reads reviewed Markdown beneath `KNOWLEDGE_DIR`. It rejects symbolic links, bounds file
-sizes, and renders returned content as text. Local processing does not make the knowledge safe to
-publish; the operator still controls and must review that content.
+The service reads reviewed Markdown beneath `KNOWLEDGE_DIR`. It rejects symbolic links and bounds
+each file, the Markdown document count, and aggregate corpus bytes before parsing document bodies.
+Returned content is rendered as text. Local processing does not make the knowledge safe to publish;
+the operator still controls and must review that content.
 
 ## Provider mode
 


### PR DESCRIPTION
## Summary

- add typed `MAX_KNOWLEDGE_DOCUMENTS` and `MAX_KNOWLEDGE_BYTES` settings with conservative defaults of 256 documents and 16 MB
- enforce document-count and aggregate-byte limits from metadata before parsing document bodies, then retain a bounded read-time check for files that change after the scan
- key cached `KnowledgeBase` instances by every limit and apply the same configured loader to readiness, chat, and collaboration
- return stable, path-free failure codes without silently skipping excess files
- document per-file versus aggregate limits in the API, architecture, trust, deployment, and maintained English/Chinese course material

Closes #84

## Verification

Passed locally:

```text
uv lock --project backend --check
python3 scripts/check_versions.py
.venv/bin/ruff check backend scripts
.venv/bin/ruff format --check backend scripts
.venv/bin/pytest -q backend/tests             # 89 passed
.venv/bin/python scripts/evaluate_collaboration.py --json
.venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json
python3 scripts/check_docs.py
npm run lint
npm run typecheck
npm test -- --run                              # 39 passed
npm run build
```

I also attempted the documented Compose smoke workflow. The local build could not fetch the digest-pinned Python/Nginx base-image metadata because `auth.docker.io` timed out; no application container ran. The PR container job remains the authoritative smoke check.