### PR TITLE
fix(api): prevent caching Q&A responses

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,14 +33,6 @@ app = FastAPI(
 )
 
 
-@app.middleware("http")
-async def private_no_cache(request: Request, call_next):
-    response = await call_next(request)
-    if request.url.path.startswith("/api/v1/personal"):
-        response.headers["Cache-Control"] = "no-store"
-    return response
-
-
 app.include_router(personal_router)
 settings = get_settings()
 app.add_middleware(RequestBodyLimitMiddleware, settings=settings)
@@ -53,6 +45,19 @@ app.add_middleware(
     expose_headers=["X-Request-ID"],
 )
 app.add_middleware(RequestIDMiddleware)
+
+
+@app.middleware("http")
+async def private_no_cache(request: Request, call_next):
+    """Prevent storage of responses that can contain personal knowledge."""
+    response = await call_next(request)
+    is_qa_response = request.method == "POST" and request.url.path in {
+        "/api/v1/chat",
+        "/api/v1/collaborate",
+    }
+    if is_qa_response or request.url.path.startswith("/api/v1/personal"):
+        response.headers["Cache-Control"] = "no-store"
+    return response
 
 
 _PROVIDER_ERROR_MESSAGES = {

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -249,6 +249,37 @@ async def test_multi_agent_collaboration_returns_typed_trace(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("endpoint", ["/api/v1/chat", "/api/v1/collaborate"])
+async def test_qa_responses_are_not_cacheable(client: httpx.AsyncClient, endpoint: str) -> None:
+    response = await client.post(endpoint, json={"question": "prefers Python tools?"})
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("endpoint", ["/api/v1/chat", "/api/v1/collaborate"])
+async def test_qa_validation_errors_are_not_cacheable(
+    client: httpx.AsyncClient, endpoint: str
+) -> None:
+    response = await client.post(endpoint, json={"question": "  "})
+
+    assert response.status_code == 422
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.anyio
+async def test_unrelated_responses_keep_their_cache_behavior(
+    client: httpx.AsyncClient,
+) -> None:
+    health = await client.get("/health")
+    ready = await client.get("/ready")
+
+    assert "cache-control" not in health.headers
+    assert "cache-control" not in ready.headers
+
+
+@pytest.mark.anyio
 async def test_verified_collaboration_returns_a_five_stage_trace(
     client: httpx.AsyncClient,
 ) -> None:
@@ -385,6 +416,7 @@ async def test_declared_oversized_request_body_is_rejected_before_parsing(
         "detail": "request body exceeds configured limit",
         "code": "request_body_too_large",
     }
+    assert response.headers["cache-control"] == "no-store"
 
 
 @pytest.mark.anyio
@@ -434,6 +466,7 @@ async def test_incomplete_provider_configuration_fails_explicitly(
         "detail": "Provider configuration is incomplete.",
         "code": "provider_configuration_incomplete",
     }
+    assert response.headers["cache-control"] == "no-store"
 
 
 REQUEST_ID_PATTERN = re.compile(r"^req_[0-9a-f]{32}$")

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -55,6 +55,12 @@ platforms, reverse proxies, model providers, browsers, and operator-added monito
 produce logs or retain data. Operators are responsible for documenting and controlling those
 systems.
 
+Responses from `POST /api/v1/chat` and `POST /api/v1/collaborate`, including handled error
+responses, set `Cache-Control: no-store` so browsers and HTTP intermediaries are instructed not to
+store Q&A content. This route-scoped policy does not disable caching for the static application,
+health, or readiness endpoints. It is an HTTP caching control, not a server, proxy, provider, or log
+retention and deletion guarantee; operators must configure those systems separately.
+
 ## What the verifier verifies
 
 The optional Verifier checks mechanical invariants after writing:


### PR DESCRIPTION
## Summary
- apply `Cache-Control: no-store` to chat and collaboration responses with an exact method/path allowlist
- cover successful, validation, request-size, and provider-error responses while leaving health/readiness caching unchanged
- document that HTTP cache prevention is distinct from retention and deletion guarantees

## Testing
- `make lint`
- `make test` (102 backend + 41 frontend tests passed)
- `make docs`
- `make evaluate` (4/4 passed)
- Container build attempted locally but Docker Hub token requests timed out; CI will run the container smoke job.

Closes #57