### PR TITLE
feat(devx): add safe knowledge preflight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,7 @@ npm run build
 Course and evaluation:
 
 ```bash
+make knowledge-check
 make docs
 make evaluate
 make version-check
@@ -122,6 +123,7 @@ update all checked metadata, regenerate locks, and let `scripts/check_versions.p
 ```bash
 make lint
 make test
+make knowledge-check
 make docs
 make evaluate
 make build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev test lint format docs evaluate build lock lock-check version-check
+.PHONY: setup dev test lint format docs evaluate knowledge-check build lock lock-check version-check
 
 UV_PROJECT_ENVIRONMENT ?= $(CURDIR)/.venv
 
@@ -36,6 +36,9 @@ version-check:
 
 evaluate:
 	.venv/bin/python scripts/evaluate_collaboration.py
+
+knowledge-check:
+	.venv/bin/python scripts/check_knowledge.py
 
 build:
 	docker compose build

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ deterministic. See the [trust documentation](docs/TRUST.md) before using private
 git clone https://github.com/jzjzzzzzzz/agent-me.git
 cd agent-me
 make setup
+make knowledge-check
 make lint test docs evaluate
 ```
 
@@ -237,6 +238,11 @@ cd frontend && npm run dev
 ```
 
 See [Lesson 00](course/00-course-setup/README.md) for platform-specific setup and troubleshooting.
+
+`make knowledge-check` safely preflights the configured Markdown corpus before startup. It reports
+only the document count and relative paths, never document contents or absolute host paths. Use
+`.venv/bin/python scripts/check_knowledge.py --knowledge-dir knowledge --json` for a stable
+machine-readable result.
 
 </details>
 

--- a/backend/tests/test_check_knowledge.py
+++ b/backend/tests/test_check_knowledge.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from app.config import Settings
+
+CHECK_KNOWLEDGE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_knowledge.py"
+CHECK_KNOWLEDGE_SPEC = importlib.util.spec_from_file_location(
+    "check_knowledge", CHECK_KNOWLEDGE_PATH
+)
+assert CHECK_KNOWLEDGE_SPEC is not None and CHECK_KNOWLEDGE_SPEC.loader is not None
+check_module = importlib.util.module_from_spec(CHECK_KNOWLEDGE_SPEC)
+sys.modules[CHECK_KNOWLEDGE_SPEC.name] = check_module
+CHECK_KNOWLEDGE_SPEC.loader.exec_module(check_module)
+
+
+def settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **overrides)
+
+
+def test_success_lists_relative_paths_in_deterministic_order(tmp_path: Path) -> None:
+    (tmp_path / "z.md").write_text("# Z\n\nLast", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "a.md").write_text("# A\n\nFirst", encoding="utf-8")
+
+    result = check_module.check_knowledge(tmp_path, settings())
+
+    assert result == check_module.KnowledgeCheckSuccess(
+        status="ok", document_count=2, paths=("nested/a.md", "z.md")
+    )
+
+
+def test_empty_and_missing_corpora_fail_safely(tmp_path: Path) -> None:
+    for directory in (tmp_path, tmp_path / "missing-private-directory"):
+        result = check_module.check_knowledge(directory, settings())
+
+        assert result == check_module.KnowledgeCheckFailure(
+            status="error", code="knowledge_corpus_empty"
+        )
+        assert str(directory) not in json.dumps(result.__dict__)
+
+
+def test_rejected_file_failures_return_only_stable_codes(tmp_path: Path) -> None:
+    private_name = tmp_path / "private-secret.md"
+    private_name.write_bytes(b"\xff")
+
+    result = check_module.check_knowledge(tmp_path, settings())
+
+    assert result == check_module.KnowledgeCheckFailure(
+        status="error", code="knowledge_document_unreadable"
+    )
+    assert "private-secret" not in json.dumps(result.__dict__)
+
+
+def test_oversized_and_symlinked_files_are_rejected(tmp_path: Path) -> None:
+    oversized = tmp_path / "oversized.md"
+    oversized.write_text("private", encoding="utf-8")
+    oversized_result = check_module.check_knowledge(tmp_path, settings(max_document_bytes=1))
+    assert oversized_result == check_module.KnowledgeCheckFailure(
+        status="error", code="knowledge_document_too_large"
+    )
+
+    oversized.unlink()
+    target = tmp_path / "target.txt"
+    target.write_text("private", encoding="utf-8")
+    (tmp_path / "linked.md").symlink_to(target)
+    symlink_result = check_module.check_knowledge(tmp_path, settings())
+    assert symlink_result == check_module.KnowledgeCheckFailure(
+        status="error", code="knowledge_symlink_rejected"
+    )
+
+
+def test_json_output_has_a_stable_shape(tmp_path: Path, capsys) -> None:
+    (tmp_path / "profile.md").write_text("# Profile\n\nSafe", encoding="utf-8")
+
+    exit_code = check_module.main(["--knowledge-dir", str(tmp_path), "--json"])
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "document_count": 1,
+        "paths": ["profile.md"],
+        "status": "ok",
+    }
+
+
+def test_error_output_is_machine_readable_and_nonzero(tmp_path: Path, capsys) -> None:
+    exit_code = check_module.main(["--knowledge-dir", str(tmp_path), "--json"])
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "code": "knowledge_corpus_empty",
+        "status": "error",
+    }

--- a/scripts/check_knowledge.py
+++ b/scripts/check_knowledge.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Safely validate the configured knowledge corpus before starting Agent-Me."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+
+from app.config import Settings
+from app.knowledge import KnowledgeBase, KnowledgeLoadError
+
+
+@dataclass(frozen=True)
+class KnowledgeCheckSuccess:
+    status: str
+    document_count: int
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class KnowledgeCheckFailure:
+    status: str
+    code: str
+
+
+def check_knowledge(
+    directory: Path, settings: Settings
+) -> KnowledgeCheckSuccess | KnowledgeCheckFailure:
+    knowledge = KnowledgeBase(
+        str(directory),
+        max_document_bytes=settings.max_document_bytes,
+        max_documents=settings.max_knowledge_documents,
+        max_corpus_bytes=settings.max_knowledge_bytes,
+    )
+    try:
+        documents = knowledge.documents()
+    except KnowledgeLoadError as error:
+        return KnowledgeCheckFailure(status="error", code=error.code)
+    if not documents:
+        return KnowledgeCheckFailure(status="error", code="knowledge_corpus_empty")
+    return KnowledgeCheckSuccess(
+        status="ok",
+        document_count=len(documents),
+        paths=tuple(document.path for document in documents),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate knowledge files without printing their contents."
+    )
+    parser.add_argument("--knowledge-dir", type=Path)
+    parser.add_argument(
+        "--json", action="store_true", help="emit machine-readable output"
+    )
+    args = parser.parse_args(argv)
+    settings = Settings()
+    directory = args.knowledge_dir or Path(settings.knowledge_dir)
+    result = check_knowledge(directory, settings)
+
+    if args.json:
+        print(json.dumps(asdict(result), sort_keys=True))
+    elif isinstance(result, KnowledgeCheckSuccess):
+        print(f"Knowledge corpus is valid ({result.document_count} documents).")
+        for path in result.paths:
+            print(f"- {path}")
+    else:
+        print(f"Knowledge corpus validation failed: {result.code}", file=sys.stderr)
+    return 0 if isinstance(result, KnowledgeCheckSuccess) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a preflight CLI that reuses the production `KnowledgeBase` loader
- provide deterministic human and JSON output without contents or absolute paths
- fail safely for empty, missing, invalid, oversized, and symlinked corpora
- expose `make knowledge-check` and document it in setup and contributor workflows

## Validation
- `make knowledge-check`
- `make lint`
- `make docs`
- `make test` (108 backend and 41 frontend tests passed)

Closes #76