### PR TITLE
feat(ci): publish evaluation summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,16 @@ jobs:
       - run: .venv/bin/ruff check backend scripts
       - run: .venv/bin/ruff format --check backend scripts
       - run: .venv/bin/pytest backend/tests
-      - run: .venv/bin/python scripts/evaluate_collaboration.py --json
-      - run: .venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json
+      - name: Publish baseline evaluation summary
+        run: |
+          set -o pipefail
+          .venv/bin/python scripts/evaluate_collaboration.py --markdown \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Publish verified evaluation summary
+        run: |
+          set -o pipefail
+          .venv/bin/python scripts/evaluate_collaboration.py --workflow verified --markdown \
+            | tee -a "$GITHUB_STEP_SUMMARY"
 
   python-minimum:
     name: Python 3.11 compatibility

--- a/backend/tests/test_evaluate_duplicate_ids.py
+++ b/backend/tests/test_evaluate_duplicate_ids.py
@@ -136,3 +136,54 @@ def test_evaluate_selection_preserves_order_and_deduplicates(
     monkeypatch.setattr(evaluator, "CollaborationOrchestrator", FakeOrchestrator)
     result = evaluator.evaluate(path, tmp_path, case_ids=["gamma", "alpha", "gamma"])
     assert [item.case_id for item in result] == ["alpha", "gamma"]
+
+
+def _result(case_id: str, *, expected: bool, actual: bool) -> evaluator.EvaluationResult:
+    return evaluator.EvaluationResult(
+        case_id=case_id,
+        expected_grounded=expected,
+        actual_grounded=actual,
+        source_count=1 if actual else 0,
+        critic_outcome="completed" if actual else "blocked",
+        passed=expected is actual,
+    )
+
+
+def test_markdown_summary_reports_an_all_pass_run() -> None:
+    summary = evaluator.markdown_summary(
+        [
+            _result("supported", expected=True, actual=True),
+            _result("unsupported", expected=False, actual=False),
+        ],
+        "verified",
+    )
+
+    assert "## Collaboration evaluation — verified" in summary
+    assert "**2/2 cases passed.**" in summary
+    assert "| supported | grounded | grounded | PASS |" in summary
+    assert "| unsupported | blocked | blocked | PASS |" in summary
+    assert "Failed cases: none" in summary
+
+
+def test_markdown_summary_reports_mixed_results_and_failed_ids() -> None:
+    summary = evaluator.markdown_summary(
+        [
+            _result("false-positive", expected=False, actual=True),
+            _result("true-positive", expected=True, actual=True),
+        ],
+        "baseline",
+    )
+
+    assert "**1/2 cases passed.**" in summary
+    assert "| false-positive | blocked | grounded | FAIL |" in summary
+    assert "Failed cases: `false-positive`" in summary
+
+
+def test_markdown_summary_escapes_sensitive_case_ids() -> None:
+    summary = evaluator.markdown_summary(
+        [_result("pipe|slash\\\n<script>", expected=True, actual=False)],
+        "baseline",
+    )
+
+    assert "pipe\\|slash\\\\<br>&lt;script&gt;" in summary
+    assert "<script>" not in summary

--- a/course/06-evaluation/README.md
+++ b/course/06-evaluation/README.md
@@ -115,6 +115,23 @@ The expected grounded labels stay unchanged; the second command proves the verif
 the known decisions while exercising its additional contract gate. It still does not measure
 semantic entailment or generalize beyond the committed fixture and knowledge files.
 
+### Read or reproduce the CI summary
+
+Pull-request CI appends a Markdown table for both baseline and verified workflows to the GitHub
+Actions job summary. Each table identifies the workflow and shows every case ID, its expected and
+actual grounded/blocked decision, pass/fail status, total passed, and failed IDs. Generate the same
+safe summary locally with:
+
+```bash
+.venv/bin/python scripts/evaluate_collaboration.py --markdown
+.venv/bin/python scripts/evaluate_collaboration.py --workflow verified --markdown
+```
+
+The summary deliberately excludes questions, answers, excerpts, environment values, and internal
+reasoning. Its pass rate measures agreement with the small, committed set of behavioral labels; it
+is not an answer-quality or factuality benchmark. CI preserves the evaluator's nonzero exit status,
+so publishing a failed summary cannot turn a regression green.
+
 ### Step 3 — add a small evaluation matrix
 
 Add at least three cases:

--- a/scripts/evaluate_collaboration.py
+++ b/scripts/evaluate_collaboration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import sys
 from dataclasses import asdict, dataclass
@@ -22,6 +23,42 @@ class EvaluationResult:
     source_count: int
     critic_outcome: str
     passed: bool
+
+
+def _markdown_cell(value: str) -> str:
+    lines = value.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    return "<br>".join(
+        html.escape(line, quote=True).replace("\\", "\\\\").replace("|", "\\|")
+        for line in lines
+    )
+
+
+def markdown_summary(results: list[EvaluationResult], workflow: str) -> str:
+    passed = sum(result.passed for result in results)
+    failed = [result.case_id for result in results if not result.passed]
+    lines = [
+        f"## Collaboration evaluation — {_markdown_cell(workflow)}",
+        "",
+        f"**{passed}/{len(results)} cases passed.**",
+        "",
+        "| Case ID | Expected | Actual | Status |",
+        "| --- | --- | --- | --- |",
+    ]
+    for result in results:
+        lines.append(
+            "| "
+            f"{_markdown_cell(result.case_id)} | "
+            f"{'grounded' if result.expected_grounded else 'blocked'} | "
+            f"{'grounded' if result.actual_grounded else 'blocked'} | "
+            f"{'PASS' if result.passed else 'FAIL'} |"
+        )
+    failed_text = (
+        ", ".join(f"`{_markdown_cell(case_id)}`" for case_id in failed)
+        if failed
+        else "none"
+    )
+    lines.extend(("", f"Failed cases: {failed_text}", ""))
+    return "\n".join(lines)
 
 
 def load_cases(path: Path) -> list[dict[str, Any]]:
@@ -103,8 +140,12 @@ def main() -> int:
         default=ROOT / "course" / "fixtures" / "collaboration_cases.json",
     )
     parser.add_argument("--knowledge-dir", type=Path, default=ROOT / "knowledge")
-    parser.add_argument(
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument(
         "--json", action="store_true", help="emit machine-readable output"
+    )
+    output.add_argument(
+        "--markdown", action="store_true", help="emit a Markdown summary"
     )
     parser.add_argument(
         "--workflow",
@@ -156,6 +197,8 @@ def main() -> int:
                 indent=2,
             )
         )
+    elif args.markdown:
+        print(markdown_summary(results, args.workflow), end="")
     else:
         print("case\texpected\tactual\tsources\tcritic\tresult")
         for result in results:


### PR DESCRIPTION
## Summary
- add `--markdown` output generated from the evaluator’s existing result objects
- report workflow, totals, per-case expected/actual decisions, status, and failed IDs
- escape Markdown/HTML-sensitive case IDs and exclude prompts, answers, excerpts, and environment data
- append baseline and verified summaries to GitHub Actions with `pipefail` preserving the merge gate
- explain the summary and its factuality limitations in Lesson 06

## Validation
- `make lint`
- `make docs`
- `make test` (111 backend and 41 frontend tests passed)
- `make evaluate`
- both local `--markdown` workflows (4/4 passed)

Closes #88