### PR TITLE
test: share collaboration fixtures across Python and TypeScript

### DIFF
--- a/backend/tests/test_collaboration_contract.py
+++ b/backend/tests/test_collaboration_contract.py
@@ -1,0 +1,58 @@
+"""Use the same public synthetic payloads as the browser's mocked-fetch tests."""
+
+import json
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+from app.main import collaborate
+from app.schemas import CollaborationRequest, CollaborationResponse
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2] / "frontend" / "src" / "__fixtures__" / "collaboration"
+)
+
+
+@pytest.fixture(params=["baseline", "verified"])
+def contract(request):
+    return request.param, json.loads(
+        (FIXTURES / f"{request.param}.json").read_text(encoding="utf-8")
+    )
+
+
+def test_shared_response_round_trips_without_shape_or_scalar_type_drift(contract) -> None:
+    _, payload = contract
+    response = CollaborationResponse.model_validate(payload)
+    serialized = json.loads(response.model_dump_json())
+
+    # Compare JSON too: Python equality alone considers True == 1 == 1.0.
+    assert json.dumps(serialized, sort_keys=True) == json.dumps(payload, sort_keys=True)
+    assert CollaborationResponse.model_validate_json(response.model_dump_json()) == response
+
+
+async def test_route_serialization_matches_the_shared_contract(contract, tmp_path, monkeypatch):
+    policy, payload = contract
+    (tmp_path / "example.md").write_text(
+        "# Example agent\n\nThe example agent plans projects from user goals.\n", encoding="utf-8"
+    )
+    monkeypatch.setattr("app.collaboration.uuid4", lambda: UUID(payload["run_id"][4:]))
+
+    response = await collaborate(
+        CollaborationRequest(question="How does the example agent plan projects?", workflow=policy),
+        Settings(_env_file=None, knowledge_dir=str(tmp_path)),
+    )
+
+    assert json.dumps(json.loads(response.model_dump_json()), sort_keys=True) == json.dumps(
+        payload, sort_keys=True
+    )
+
+
+def test_shared_response_rejects_an_unsupported_metric_value(contract) -> None:
+    _, payload = contract
+    payload["trace"][0]["metrics"]["task_count"] = {"unsupported": "nested object"}
+
+    with pytest.raises(ValidationError, match="task_count"):
+        CollaborationResponse.model_validate(payload)

--- a/course/04-typed-orchestration/README.md
+++ b/course/04-typed-orchestration/README.md
@@ -106,11 +106,24 @@ Write the same path for `run_id`, including where its format is enforced.
 ### Step 3 — run contract tests
 
 ```bash
-.venv/bin/pytest -q backend/tests/test_collaboration.py backend/tests/test_api.py
+.venv/bin/pytest -q backend/tests/test_collaboration.py backend/tests/test_api.py backend/tests/test_collaboration_contract.py
 cd frontend
-npm test -- --run src/api.test.ts src/App.test.tsx
+npm test -- --run src/api.test.ts src/collaborationContract.test.ts src/App.test.tsx
 cd ..
 ```
+
+The [shared contract fixtures](../../frontend/src/__fixtures__/collaboration/README.md) contain
+one four-stage baseline response and one five-stage verified response. Python validates both with
+`CollaborationResponse`, checks JSON serialization without scalar-type drift, and compares the real
+route serializer against the same synthetic corpus. TypeScript imports these exact JSON files and
+passes them through mocked `fetch` and the existing runtime parser. Derived invalid cases exercise
+stage-order rejection in the browser and unsupported metric objects in both suites.
+
+These tests show that **these two examples** agree across the producer and consumer. They do not
+prove every possible response is valid, that the validators enforce identical invariants (Pydantic
+alone does not check workflow stage order), or that an answer is factually correct. Keep the wider
+malformed-response tests, role tests, and behavioral evaluations. Fixtures are public test data,
+not production answers, private prompt snapshots, or a runtime fallback.
 
 ### Step 4 — make a controlled internal change
 

--- a/course/translations/zh-CN/04-typed-orchestration/README.md
+++ b/course/translations/zh-CN/04-typed-orchestration/README.md
@@ -80,11 +80,20 @@ PY
 ### 运行协议测试
 
 ```bash
-.venv/bin/pytest -q backend/tests/test_collaboration.py backend/tests/test_api.py
+.venv/bin/pytest -q backend/tests/test_collaboration.py backend/tests/test_api.py backend/tests/test_collaboration_contract.py
 cd frontend
-npm test -- --run src/api.test.ts src/App.test.tsx
+npm test -- --run src/api.test.ts src/collaborationContract.test.ts src/App.test.tsx
 cd ..
 ```
+
+[共享协议 fixture](../../../../frontend/src/__fixtures__/collaboration/README.md) 包含四阶段 baseline
+和五阶段 verified 各一份合成响应。Python 用 `CollaborationResponse` 校验、检查 JSON 序列化的字段与
+标量类型，并用相同合成语料核对实际路由序列化。TypeScript 直接导入同一对 JSON，经 mocked `fetch`
+进入现有运行时 parser。派生的非法样本验证浏览器拒绝错误阶段顺序，并验证两端拒绝对象类型 metric。
+
+这证明的是**这两个样本**在生产者与消费者之间兼容，不是所有响应都合法，也不说明两端校验了相同
+不变量（单独的 Pydantic 模型不检查 workflow 阶段顺序），更不保证答案事实正确。仍须保留其他非法响应
+测试、角色测试与行为评估。Fixture 只含公开合成测试数据，不是生产答案、私密问题快照或运行时 fallback。
 
 ### 受控改动
 

--- a/frontend/src/__fixtures__/collaboration/README.md
+++ b/frontend/src/__fixtures__/collaboration/README.md
@@ -1,0 +1,14 @@
+# Shared collaboration contract fixtures
+
+`baseline.json` and `verified.json` are canonical, synthetic responses with deterministic
+server-shaped run IDs. Both the Python and TypeScript contract tests consume these exact files.
+They are test-only data, never runtime fallback answers; do not import them from application code.
+
+The synthetic corpus and question used to verify route serialization live in
+[`test_collaboration_contract.py`](../../../../backend/tests/test_collaboration_contract.py).
+Update the fixtures deliberately when changing the public contract; do not regenerate them merely
+to silence a regression. Invalid cases are derived in tests rather than stored as duplicate payloads.
+
+This directory is inside the existing `frontend/` Docker build context. Native tests, CI, and the
+frontend image's TypeScript build need no extra copy scripts or broadened Docker context. Vite does
+not bundle test files or these fixtures into the production application.

--- a/frontend/src/__fixtures__/collaboration/baseline.json
+++ b/frontend/src/__fixtures__/collaboration/baseline.json
@@ -1,0 +1,57 @@
+{
+  "run_id": "run_11111111111111111111111111111111",
+  "workflow": "planner-researcher-critic-writer",
+  "mode": "multi-agent-local",
+  "answer": "The example agent plans projects from user goals.\n\nSources: [example.md]",
+  "grounded": true,
+  "sources": [
+    {
+      "title": "Example agent",
+      "path": "example.md",
+      "excerpt": "The example agent plans projects from user goals.",
+      "score": 0.75
+    }
+  ],
+  "trace": [
+    {
+      "sequence": 1,
+      "agent": "planner",
+      "outcome": "completed",
+      "summary": "Created an evidence-first execution plan.",
+      "metrics": {
+        "task_count": 3,
+        "query_term_count": 7
+      }
+    },
+    {
+      "sequence": 2,
+      "agent": "researcher",
+      "outcome": "completed",
+      "summary": "Collected ranked excerpts from the local knowledge base.",
+      "metrics": {
+        "evidence_count": 1,
+        "document_count": 1
+      }
+    },
+    {
+      "sequence": 3,
+      "agent": "critic",
+      "outcome": "completed",
+      "summary": "Approved the evidence for grounded synthesis.",
+      "metrics": {
+        "approved": true,
+        "query_coverage": 0.5714
+      }
+    },
+    {
+      "sequence": 4,
+      "agent": "writer",
+      "outcome": "completed",
+      "summary": "Produced a cited answer from approved evidence.",
+      "metrics": {
+        "answer_chars": 72,
+        "citation_count": 1
+      }
+    }
+  ]
+}

--- a/frontend/src/__fixtures__/collaboration/verified.json
+++ b/frontend/src/__fixtures__/collaboration/verified.json
@@ -1,0 +1,69 @@
+{
+  "run_id": "run_22222222222222222222222222222222",
+  "workflow": "planner-researcher-critic-writer-verifier",
+  "mode": "multi-agent-local",
+  "answer": "The example agent plans projects from user goals.\n\nSources: [example.md]",
+  "grounded": true,
+  "sources": [
+    {
+      "title": "Example agent",
+      "path": "example.md",
+      "excerpt": "The example agent plans projects from user goals.",
+      "score": 0.75
+    }
+  ],
+  "trace": [
+    {
+      "sequence": 1,
+      "agent": "planner",
+      "outcome": "completed",
+      "summary": "Created an evidence-first execution plan.",
+      "metrics": {
+        "task_count": 3,
+        "query_term_count": 7
+      }
+    },
+    {
+      "sequence": 2,
+      "agent": "researcher",
+      "outcome": "completed",
+      "summary": "Collected ranked excerpts from the local knowledge base.",
+      "metrics": {
+        "evidence_count": 1,
+        "document_count": 1
+      }
+    },
+    {
+      "sequence": 3,
+      "agent": "critic",
+      "outcome": "completed",
+      "summary": "Approved the evidence for grounded synthesis.",
+      "metrics": {
+        "approved": true,
+        "query_coverage": 0.5714
+      }
+    },
+    {
+      "sequence": 4,
+      "agent": "writer",
+      "outcome": "completed",
+      "summary": "Produced a cited answer from approved evidence.",
+      "metrics": {
+        "answer_chars": 72,
+        "citation_count": 1
+      }
+    },
+    {
+      "sequence": 5,
+      "agent": "verifier",
+      "outcome": "completed",
+      "summary": "Verified citation paths and answer metadata.",
+      "metrics": {
+        "approved": true,
+        "citation_paths_valid": true,
+        "expected_citation_count": 1,
+        "reported_citation_count": 1
+      }
+    }
+  ]
+}

--- a/frontend/src/collaborationContract.test.ts
+++ b/frontend/src/collaborationContract.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { collaborate, type CollaborationPolicy } from "./api";
+import baseline from "./__fixtures__/collaboration/baseline.json";
+import verified from "./__fixtures__/collaboration/verified.json";
+
+afterEach(() => vi.unstubAllGlobals());
+
+const contracts: [CollaborationPolicy, typeof baseline | typeof verified][] = [
+  ["baseline", baseline],
+  ["verified", verified],
+];
+
+it.each(contracts)("parses the shared %s response through mocked fetch", async (policy, payload) => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => payload });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(collaborate("Synthetic question", policy)).resolves.toEqual(payload);
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/v1/collaborate",
+    expect.objectContaining({
+      body: JSON.stringify({ question: "Synthetic question", workflow: policy }),
+    }),
+  );
+});
+
+it.each(contracts)("rejects reordered stages derived from %s", async (policy, fixture) => {
+  const payload = structuredClone(fixture);
+  [payload.trace[0].agent, payload.trace[1].agent] =
+    [payload.trace[1].agent, payload.trace[0].agent];
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => payload }));
+
+  await expect(collaborate("Synthetic question", policy)).rejects.toMatchObject({
+    code: "invalid_trace",
+  });
+});
+
+it.each(contracts)("rejects unsupported metrics derived from %s", async (policy, fixture) => {
+  const payload = {
+    ...fixture,
+    trace: fixture.trace.map((stage, index) => index === 0
+      ? { ...stage, metrics: { task_count: { unsupported: "nested object" } } }
+      : stage),
+  };
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => payload }));
+
+  await expect(collaborate("Synthetic question", policy)).rejects.toMatchObject({
+    code: "invalid_trace",
+  });
+});


### PR DESCRIPTION
## Problem and scope

Closes #85. Add a small shared, test-only compatibility baseline for Python and TypeScript without duplicating production schemas or parsers.

## What changed

- Canonical synthetic baseline and verified JSON responses under `frontend/src/__fixtures__/collaboration/`, inside the existing frontend Docker build context.
- Python model validation, type-sensitive JSON round trips, real route serialization checks, and derived invalid metric tests.
- Mocked-fetch browser contract tests for both workflows, reordered stages, and unsupported metric values.
- English and Simplified Chinese Lesson 04 explain guarantees and limits, including the fact that Pydantic alone does not enforce stage order.

## Verification evidence

- [x] `make lint`
- [x] `make test` — 117 backend / 47 frontend tests passed
- [x] `make docs`
- [x] `make evaluate` — baseline 4/4
- [ ] `make build` — attempted; Docker Hub authentication timed out fetching pinned Python/nginx base images (`auth.docker.io/token`). No Dockerfile/context changes were needed.
- `make knowledge-check`, `npm run build`, `scripts/check_private_data.py` passed.
- Verified evaluation (`.venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json`): 4/4 passed.

## Course and translation impact

- [x] English course/docs updated.
- [x] Maintained Simplified Chinese lesson updated.
- [x] New commands and links run/checked.

Translation is machine-assisted; no independent human review is claimed.

## Security and privacy impact

Only public synthetic knowledge and deterministic test IDs are included. No production prompts, private records, credentials, configuration, or runtime fixture imports. No authorization, retention, logging, or provider changes.

## Compatibility, migration, and rollback

Test/docs-only change; no API, schema, parser, dependencies, or release metadata changes. Revert the commit if needed.

## Known limitations

Two examples are compatibility evidence, not exhaustive equivalence or factual-correctness proof. Full container build remains to be confirmed by CI because of the local registry timeout.
