### PR TITLE
fix: ignore fenced Markdown examples in documentation link checks

### DIFF
--- a/backend/tests/test_check_docs.py
+++ b/backend/tests/test_check_docs.py
@@ -1,11 +1,64 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 CHECK_DOCS_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_docs.py"
 CHECK_DOCS_SPEC = importlib.util.spec_from_file_location("check_docs", CHECK_DOCS_PATH)
 assert CHECK_DOCS_SPEC is not None and CHECK_DOCS_SPEC.loader is not None
 check_docs = importlib.util.module_from_spec(CHECK_DOCS_SPEC)
 CHECK_DOCS_SPEC.loader.exec_module(check_docs)
+
+
+@pytest.mark.parametrize(
+    "opening,closing",
+    [("```", "```"), ("```markdown", "````"), ("~~~", "~~~"), ("   ~~~~markdown", "  ~~~~~\t")],
+)
+def test_fenced_examples_are_not_links(tmp_path: Path, monkeypatch, opening, closing) -> None:
+    source = tmp_path / "source.md"
+    source.write_text(
+        f"# Present\n{opening}\n[example](missing.md)\n[anchor](#absent)\n"
+        "[outside](../outside.md)\n[owner](https://github.com/wrong/agent-me)\n"
+        f"{closing}\n[valid](#present)\n[broken](real-missing.md)\n[anchor](#real-absent)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+    assert check_docs.validate_file(source) == [
+        "source.md: missing local link: real-missing.md",
+        "source.md: missing Markdown anchor in source.md: #real-absent",
+    ]
+
+
+@pytest.mark.parametrize("false_close", ["```", "~~~~", "```` extra", "    ````"])
+def test_only_matching_fences_close_examples(tmp_path: Path, monkeypatch, false_close) -> None:
+    source = tmp_path / "source.md"
+    source.write_text(
+        f"````markdown\n{false_close}\n[example](missing.md)\n# Hidden\n"
+        "````\n[broken](after.md)\n# Visible\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+    assert check_docs.validate_file(source) == ["source.md: missing local link: after.md"]
+    assert check_docs.heading_anchors(source.read_text()) == {"visible"}
+
+
+@pytest.mark.parametrize("opening", ["```python", "~~~markdown"])
+def test_unclosed_fence_keeps_merge_marker_check(tmp_path: Path, monkeypatch, opening) -> None:
+    source = tmp_path / "source.md"
+    source.write_text(
+        f"[broken](before.md)\n{opening}\n[example](missing.md)\n<<<<<<< ours\n# Hidden\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+    assert check_docs.validate_file(source) == [
+        "source.md: unresolved merge marker <<<<<<<",
+        "source.md: missing local link: before.md",
+    ]
+    assert check_docs.heading_anchors(source.read_text()) == set()
+
+
+def test_fence_removal_does_not_create_setext_heading() -> None:
+    assert check_docs.markdown_headings("Not a heading\n```\nexample\n```\n---\n") == []
 
 
 def test_heading_anchors_follow_github_slug_rules() -> None:

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -118,21 +118,21 @@ def github_slug(value: str) -> str:
     return "".join(result)
 
 
-def markdown_headings(text: str) -> list[str]:
+def unfenced_lines(text: str) -> list[str]:
+    """Blank fenced examples while preserving boundaries between surrounding lines."""
     lines = text.splitlines()
-    headings: list[str] = []
-    outside_fence = [True] * len(lines)
     fence_character = ""
     fence_length = 0
 
     for index, line in enumerate(lines):
         fence = FENCE.match(line)
         if fence_character:
-            outside_fence[index] = False
-            stripped = line.lstrip()
+            lines[index] = ""
             if (
-                stripped.startswith(fence_character * fence_length)
-                and not stripped.strip(fence_character).strip()
+                fence
+                and fence.group(1)[0] == fence_character
+                and len(fence.group(1)) >= fence_length
+                and not line[fence.end() :].strip()
             ):
                 fence_character = ""
                 fence_length = 0
@@ -141,13 +141,20 @@ def markdown_headings(text: str) -> list[str]:
             marker = fence.group(1)
             fence_character = marker[0]
             fence_length = len(marker)
-            outside_fence[index] = False
+            lines[index] = ""
             continue
 
+    return lines
+
+
+def markdown_headings(text: str) -> list[str]:
+    lines = unfenced_lines(text)
+    headings: list[str] = []
+
+    for index, line in enumerate(lines):
         if (
             index
             and SETEXT_HEADING.match(line)
-            and outside_fence[index - 1]
             and lines[index - 1].strip()
             and not ATX_HEADING.match(lines[index - 1])
         ):
@@ -183,7 +190,7 @@ def validate_file(path: Path) -> list[str]:
     for marker in MERGE_MARKERS:
         if any(line.startswith(marker) for line in text.splitlines()):
             errors.append(f"{path.relative_to(ROOT)}: unresolved merge marker {marker}")
-    for raw_destination in LINK.findall(text):
+    for raw_destination in LINK.findall("\n".join(unfenced_lines(text))):
         destination, fragment = destination_parts(raw_destination)
         if not destination and not fragment:
             continue


### PR DESCRIPTION
## Problem and scope

Closes #108. Literal Markdown links inside fenced examples currently fail the documentation gate. This change skips those examples while preserving validation of links outside them.

## What changed

- Extract the fence scan into a shared helper used by headings and links. Blank fenced lines to preserve boundaries for Setext headings.
- Require matching closing-fence characters, sufficient length, and at most three leading spaces.
- Add temporary-file regression coverage for backtick/tilde and language-tagged fences, invalid closing fences, unclosed blocks, links immediately after a closing fence, and merge markers inside examples.

## Verification evidence

- [x] `make lint`
- [x] `make test` — 122 backend tests and 41 frontend tests passed.
- [x] `make docs` — 51 Markdown files, 16 maintained lesson pages.
- [x] `make evaluate` — 4/4 passed.
- [ ] `make build` — attempted; Docker is not installed locally.
- `make knowledge-check`, frontend `npm run build`, `scripts/check_private_data.py`, and `git diff --check` passed.
- Focused checker suite: 10 regression cases failed before the implementation; all 15 tests passed afterward.
- Python 3.13.5, uv 0.12.10, Node 22.23.2. The initial frontend run on system Node 26 failed in localStorage setup; rerunning with the repository's specified Node 22 passed.

## Course and translation impact

- [x] No course behavior or explanation changed.
- No course pages or translations edited. Existing documentation checks passed.

## Security and privacy impact

- [x] No secrets, environment contents, private documents, production prompts, database files, or personal records are included.
- Tests use synthetic temporary files. The independent merge-marker scan remains on the original text; repository-boundary, GitHub-owner, and heading-anchor checks remain active for real links.
- No application rendering, authorization, retention, logging, or provider changes.

## Compatibility, migration, and rollback

No dependencies, public APIs, schemas, or migrations change. Revert these changes to restore the previous checker behavior.

## Known limitations

Full CommonMark compliance, inline-code/reference-link parsing, and external link crawling remain outside scope. Container validation remains for CI.

AI-assisted implementation and test execution; no independent human-review claim. Published as two browser commits because the GitHub integration cannot write to the fork; these form one focused fix and can be squashed.
