### PR TITLE
fix: validate FastAPI version binding structurally

### DIFF
--- a/backend/tests/test_check_versions.py
+++ b/backend/tests/test_check_versions.py
@@ -1,0 +1,114 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_versions.py"
+SPEC = importlib.util.spec_from_file_location("check_versions", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+check_versions = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(check_versions)
+
+
+@pytest.fixture
+def repository(tmp_path, monkeypatch):
+    files = {
+        "VERSION": "2.0.0\n",
+        "backend/pyproject.toml": '[project]\nname="example"\nversion="2.0.0"\n',
+        "backend/app/__init__.py": '__version__ = "2.0.0"\n',
+        "backend/app/main.py": "app = FastAPI(version=__version__)\n",
+        "backend/uv.lock": (
+            '[[package]]\nname="third-party"\nversion="9.9.9"\n'
+            '[package.source]\nregistry="https://example.invalid"\n'
+            '[[package]]\nname="example"\nversion="2.0.0"\n'
+            '[package.source]\neditable="."\n'
+        ),
+        "frontend/package.json": json.dumps({"version": "2.0.0"}),
+        "frontend/package-lock.json": json.dumps(
+            {"version": "2.0.0", "packages": {"": {"version": "2.0.0"}}}
+        ),
+    }
+    for name, content in files.items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(check_versions, "ROOT", tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "app = FastAPI(version=__version__)",
+        "app = FastAPI(version = __version__)",
+        "app = FastAPI(\n title='Example',\n version=__version__,\n)",
+        "raise RuntimeError('must not execute')\napp = FastAPI(version=__version__)",
+    ],
+)
+def test_consistent_metadata_passes_without_executing_source(repository, capsys, source):
+    (repository / "backend/app/main.py").write_text(source, encoding="utf-8")
+    assert check_versions.main() == 0
+    assert "Version consistency check passed (2.0.0)." in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'app = FastAPI(version="0.0.0")',
+        "app = FastAPI()",
+        '# version=__version__\napp = FastAPI(version="0.0.0")',
+        'note = "version=__version__"\napp = FastAPI()',
+        "other = FastAPI(version=__version__)\napp = FastAPI()",
+        "app = Other(version=__version__)",
+        "def factory():\n    app = FastAPI(version=__version__)",
+    ],
+)
+def test_wrong_binding_fails_despite_decoy_text(repository, capsys, source):
+    (repository / "backend/app/main.py").write_text(source, encoding="utf-8")
+    assert check_versions.main() == 1
+    assert (
+        "backend/app/main.py: FastAPI metadata must use app.__version__" in capsys.readouterr().err
+    )
+
+
+def test_invalid_python_is_a_diagnostic(repository, capsys):
+    (repository / "backend/app/main.py").write_text("app = FastAPI(\n", encoding="utf-8")
+    assert check_versions.main() == 1
+    assert "backend/app/main.py: invalid Python" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "filename,old,new,diagnostic",
+    [
+        ("backend/pyproject.toml", 'version="2.0.0"', 'version="1.0.0"', "backend/pyproject.toml"),
+        ("backend/app/__init__.py", '"2.0.0"', '"1.0.0"', "backend/app/__init__.py"),
+        ("backend/uv.lock", 'version="2.0.0"', 'version="1.0.0"', "backend/uv.lock"),
+        ("backend/uv.lock", 'editable="."', 'editable="elsewhere"', "backend/uv.lock"),
+        ("frontend/package.json", '"2.0.0"', '"1.0.0"', "frontend/package.json"),
+        (
+            "frontend/package-lock.json",
+            '"version": "2.0.0"',
+            '"version": "1.0.0"',
+            "frontend/package-lock.json (root)",
+        ),
+        (
+            "frontend/package-lock.json",
+            '"": {"version": "2.0.0"}',
+            '"": {"version": "1.0.0"}',
+            "frontend/package-lock.json (package)",
+        ),
+    ],
+)
+def test_metadata_drift_is_still_reported(repository, capsys, filename, old, new, diagnostic):
+    target = repository / filename
+    target.write_text(target.read_text().replace(old, new, 1), encoding="utf-8")
+    assert check_versions.main() == 1
+    assert f"{diagnostic}: expected '2.0.0', found" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("version", ["01.0.0", "2.0", "2.0.0-rc1", "v2.0.0"])
+def test_stable_version_rules_remain(repository, capsys, version):
+    (repository / "VERSION").write_text(version, encoding="utf-8")
+    assert check_versions.main() == 1
+    assert "VERSION: expected a stable MAJOR.MINOR.PATCH value" in capsys.readouterr().err

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -37,6 +37,29 @@ def app_version(path: Path) -> str | None:
     return None
 
 
+def uses_app_version(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not any(
+            isinstance(target, ast.Name) and target.id == "app"
+            for target in node.targets
+        ):
+            continue
+        call = node.value
+        if not (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "FastAPI"
+        ):
+            return False
+        return any(
+            keyword.arg == "version"
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id == "__version__"
+            for keyword in call.keywords
+        )
+    return False
+
+
 def main() -> int:
     expected = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
     errors: list[str] = []
@@ -88,8 +111,17 @@ def main() -> int:
             errors.append(f"{source}: expected {expected!r}, found {actual!r}")
 
     main_source = (ROOT / "backend" / "app" / "main.py").read_text(encoding="utf-8")
-    if "version=__version__" not in main_source:
-        errors.append("backend/app/main.py: FastAPI metadata must use app.__version__")
+    try:
+        main_tree = ast.parse(main_source, filename="backend/app/main.py")
+    except SyntaxError as error:
+        errors.append(
+            f"backend/app/main.py: invalid Python at line {error.lineno}: {error.msg}"
+        )
+    else:
+        if not uses_app_version(main_tree):
+            errors.append(
+                "backend/app/main.py: FastAPI metadata must use app.__version__"
+            )
 
     if errors:
         print("Version consistency check failed:", file=sys.stderr)


### PR DESCRIPTION
## Problem and scope

Closes #110. The version checker currently rejects `version = __version__` and can accept a hardcoded version when a comment or unrelated expression contains the expected substring.

## What changed

- Inspect the top-level `app = FastAPI(...)` assignment using the standard-library AST and require the `version` keyword to reference `__version__`.
- Report invalid Python with the file name, line, and syntax diagnostic; never import or execute the application.
- Add 23 synthetic temporary-repository tests covering valid formatting, misleading comments/strings/calls, syntax errors, backend/frontend metadata drift, editable root-package selection, and stable-version rules.

## Verification evidence

- [x] `make lint`
- [x] `make test` — 134 backend and 41 frontend tests passed.
- [x] `make docs` — 51 Markdown files and 16 maintained lessons.
- [x] `make evaluate` — 4/4 passed.
- [ ] `make build` — attempted; Docker is not installed locally.
- Focused suite: seven cases failed against the original code; all 23 passed after the fix.
- `make knowledge-check`, `make version-check`, frontend `npm run build`, `scripts/check_private_data.py`, and `git diff --check` passed.
- Python 3.13.5, uv 0.12.10, Node 22.23.2.

## Course and translation impact

No course explanations, pages, or translations changed. Existing documentation checks passed.

## Security and privacy impact

Only synthetic temporary metadata is used in tests. No credentials, private records, or real release files are modified. Application source is parsed, not executed; a regression fixture deliberately raises if executed. No provider, authorization, retention, or logging changes.

## Compatibility, migration, and rollback

Existing stable-version syntax and package mismatch diagnostics are preserved. No release bump, dependency update, public API change, or migration. Revert the two-file change to restore the prior checker.

## Known limitations

Supports the repository's direct top-level assignment style; arbitrary aliases and dynamic factories remain out of scope. Docker validation remains for CI.

AI-assisted implementation and testing; no independent human-review claim. The browser publication uses two commits forming one focused change; squash if preferred.
