### PR TITLE
fix: respect the profile question limit in private chat

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { App } from "./App";
 import { downloadCollaborationRun } from "./exportRun";
@@ -19,6 +19,19 @@ const profileResponse = {
     external_provider_enabled: false,
   }),
 };
+
+it("passes the configured question limit to the private workspace", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => ({
+    ok: true,
+    json: async () => url.endsWith("/api/v1/profile")
+      ? { name: "Synthetic twin", description: "Example", max_question_chars: 42, external_provider_enabled: false, personal_enabled: true }
+      : [],
+  })));
+  render(<App />);
+  fireEvent.change(await screen.findByLabelText(/Workspace token/), { target: { value: "synthetic-token" } });
+  fireEvent.click(screen.getByRole("button", { name: /Unlock/ }));
+  expect(await screen.findByLabelText(/Private question/)).toHaveAttribute("maxlength", "42");
+});
 
 function routeFetch(chatResponse: object) {
   return vi.fn().mockImplementation((url: string) =>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -163,7 +163,7 @@ export function App() {
         </div>
       </header>
 
-      {profile?.personal_enabled && <PersonalWorkspace external={profile.external_provider_enabled} />}
+      {profile?.personal_enabled && <PersonalWorkspace external={profile.external_provider_enabled} maxQuestionChars={maxQuestionChars} />}
 
       <form onSubmit={submit} aria-busy={loading}>
         <fieldset className="workflow-picker">

--- a/frontend/src/PersonalWorkspace.test.tsx
+++ b/frontend/src/PersonalWorkspace.test.tsx
@@ -4,6 +4,44 @@ import { PersonalWorkspace } from "./PersonalWorkspace";
 
 afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
 
+it.each([[42, 42], [undefined, 8000], [12000, 8000]])("enforces configured limit %s with an effective boundary of %s", async (configured, limit) => {
+  const fetcher = vi.fn(async () => new Response(JSON.stringify([]), { status: 200 }));
+  vi.stubGlobal("fetch", fetcher);
+  render(<PersonalWorkspace external={false} maxQuestionChars={configured} />);
+  fireEvent.change(screen.getByLabelText(/Workspace token/), { target: { value: "synthetic-token" } });
+  fireEvent.click(screen.getByRole("button", { name: /Unlock/ }));
+  const question = await screen.findByLabelText(/Private question/);
+  expect(question).toHaveAttribute("maxlength", String(limit));
+  const form = question.closest("form")!;
+  fireEvent.change(question, { target: { value: "x".repeat(limit + 1) } });
+  fireEvent.submit(form);
+  expect(fetcher).toHaveBeenCalledTimes(2);
+  expect(question).toHaveValue("x".repeat(limit + 1));
+  fireEvent.change(question, { target: { value: "x".repeat(limit) } });
+  fireEvent.submit(form);
+  await waitFor(() => expect(fetcher).toHaveBeenCalledWith(expect.stringContaining("/chat"), expect.objectContaining({ body: JSON.stringify({ question: "x".repeat(limit) }) })));
+  await waitFor(() => expect(question).toHaveValue(""));
+});
+
+it("preserves a draft when the limit shrinks and allows sending after shortening", async () => {
+  const fetcher = vi.fn(async () => new Response(JSON.stringify([]), { status: 200 }));
+  vi.stubGlobal("fetch", fetcher);
+  const { rerender } = render(<PersonalWorkspace external={false} maxQuestionChars={100} />);
+  fireEvent.change(screen.getByLabelText(/Workspace token/), { target: { value: "synthetic-token" } });
+  fireEvent.click(screen.getByRole("button", { name: /Unlock/ }));
+  const question = await screen.findByLabelText(/Private question/);
+  fireEvent.change(question, { target: { value: "x".repeat(43) } });
+  rerender(<PersonalWorkspace external={false} maxQuestionChars={42} />);
+  expect(question).toHaveValue("x".repeat(43));
+  expect(screen.getByRole("button", { name: /Send/ })).toBeDisabled();
+  fireEvent.submit(question.closest("form")!);
+  expect(fetcher).toHaveBeenCalledTimes(2);
+  fireEvent.change(question, { target: { value: "shortened question" } });
+  expect(screen.getByRole("button", { name: /Send/ })).toBeEnabled();
+  fireEvent.click(screen.getByRole("button", { name: /Send/ }));
+  await waitFor(() => expect(question).toHaveValue(""));
+});
+
 it("requires a token, loads persisted memory, and clears private state on lock", async () => {
   const fetcher = vi.fn(async (url: string) => new Response(JSON.stringify(
     url.endsWith("/entries") ? [{ id: "one", key: "identity.name", kind: "fact", content: "Alex Example", status: "confirmed", source: "manual", updated_at: "2026-01-01" }] : [{ id: "turn", role: "user", content: "Saved question" }],

--- a/frontend/src/PersonalWorkspace.tsx
+++ b/frontend/src/PersonalWorkspace.tsx
@@ -4,7 +4,8 @@ type Entry = { id: string; kind: string; key: string; content: string; status: s
 type Turn = { id: string; role: string; content: string };
 const base = (import.meta.env.VITE_API_BASE_URL ?? "").trim().replace(/\/+$/, "");
 
-export function PersonalWorkspace({ external }: { external: boolean }) {
+export function PersonalWorkspace({ external, maxQuestionChars = 8000 }: { external: boolean; maxQuestionChars?: number }) {
+  const questionLimit = Math.min(maxQuestionChars, 8000);
   const [token, setToken] = useState("");
   const [unlocked, setUnlocked] = useState(false);
   const [entries, setEntries] = useState<Entry[]>([]);
@@ -91,9 +92,9 @@ export function PersonalWorkspace({ external }: { external: boolean }) {
       <h3>私有聊天 / Private chat</h3>
       <p>使用“记住：…”或“Remember: …”生成候选偏好，再到上方确认。其他信息可手动添加。</p>
       <div className="private-history">{history.map(turn => <article key={turn.id}><strong>{turn.role}</strong><p>{turn.content}</p></article>)}</div>
-      <form onSubmit={e => { e.preventDefault(); void run(async () => { await request("/chat", { question }); setQuestion(""); await refresh(); }); }}>
-        <label>私有问题 / Private question<textarea required maxLength={8000} value={question} onChange={e => setQuestion(e.target.value)} /></label>
-        <button disabled={busy}>发送 / Send</button>
+      <form onSubmit={e => { e.preventDefault(); if (busy || question.length > questionLimit) return; void run(async () => { await request("/chat", { question }); setQuestion(""); await refresh(); }); }}>
+        <label>私有问题 / Private question<textarea required maxLength={questionLimit} value={question} onChange={e => setQuestion(e.target.value)} /></label>
+        <button disabled={busy || question.length > questionLimit}>发送 / Send</button>
       </form>
       <button disabled={busy} onClick={() => void run(async () => { await request("/history/clear", {}); await refresh(); })}>清空全部聊天（保留记忆） / Clear history</button>
       <button disabled={busy} onClick={() => void run(async () => {


### PR DESCRIPTION
## Problem and scope
Closes #109. Private chat previously allowed 8,000 characters even when the profile configured a smaller question limit.

## What changed
- Pass the profile limit into PersonalWorkspace and cap it at 8,000, with the existing default.
- Apply the effective limit to the textarea and guard submission if an existing draft exceeds a newly reduced limit. Preserve the draft so the user can shorten it.
- Cover smaller/default/oversized profile limits, exact-boundary submission, a limit reduced after typing, and the actual App-to-workspace integration.

## Verification evidence
- [x] `make lint`
- [x] `make test` — 111 backend and 46 frontend tests passed.
- [x] `make docs` — 51 files / 16 lessons.
- [x] `make evaluate` — 4/4.
- [ ] `make build` — attempted; Docker is unavailable locally.
- Frontend production build, knowledge check, private-data guard, and diff whitespace check passed.
- All five added tests failed before the fix and passed afterward; focused frontend suite: 26 passed.
- Node 22.23.2; local PYTHONPATH set to work around macOS hidden editable-install .pth files.

## Course and translation impact
- [x] No course behavior or explanation changed.
Translation/review status: no strings or translations changed.

## Security and privacy impact
- [x] No secrets, private documents, or personal records included.
- [x] Untrusted text remains safely rendered and bounded.
- [x] Authorization and external-provider impact considered.
The existing backend validation remains authoritative; this aligns the private frontend with the configured limit.

## Compatibility, migration, and rollback
No API/schema changes or migration. The optional component prop defaults to 8,000. Revert if private-chat submission regresses.

## Known limitations
AI-assisted implementation and test execution; no independent human-review claim. Docker/container verification remains for CI. Published through four browser commits, which can be squashed.