### PR TITLE
Fix inline code handling in documentation link checks

### DIFF
--- a/backend/tests/test_check_docs.py
+++ b/backend/tests/test_check_docs.py
@@ -29,6 +29,55 @@ def test_fenced_examples_are_not_links(tmp_path: Path, monkeypatch, opening, clo
     ]
 
 
+@pytest.mark.parametrize(
+    "span",
+    [
+        "`[example](missing.md)`",
+        "``[example](missing.md)``",
+        "```Use `[example](missing.md)` syntax```",
+    ],
+)
+def test_inline_code_examples_are_not_links(tmp_path: Path, monkeypatch, span) -> None:
+    source = tmp_path / "source.md"
+    source.write_text(f"Use {span}.\n", encoding="utf-8")
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+
+    assert check_docs.validate_file(source) == []
+
+
+def test_inline_code_does_not_hide_adjacent_links(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "source.md"
+    source.write_text(
+        "Use `[example](missing.md)`, then follow [broken](real-missing.md).\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+
+    assert check_docs.validate_file(source) == ["source.md: missing local link: real-missing.md"]
+
+
+def test_inline_code_does_not_join_link_fragments(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "source.md"
+    source.write_text("[not a link]`example`(missing.md)\n", encoding="utf-8")
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+
+    assert check_docs.validate_file(source) == []
+
+
+def test_unmatched_backticks_do_not_hide_later_links(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "source.md"
+    source.write_text(
+        "Use `[first](first-missing.md) as syntax.\n[second](second-missing.md)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(check_docs, "ROOT", tmp_path)
+
+    assert check_docs.validate_file(source) == [
+        "source.md: missing local link: first-missing.md",
+        "source.md: missing local link: second-missing.md",
+    ]
+
+
 @pytest.mark.parametrize("false_close", ["```", "~~~~", "```` extra", "    ````"])
 def test_only_matching_fences_close_examples(tmp_path: Path, monkeypatch, false_close) -> None:
     source = tmp_path / "source.md"

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -190,7 +190,9 @@ def validate_file(path: Path) -> list[str]:
     for marker in MERGE_MARKERS:
         if any(line.startswith(marker) for line in text.splitlines()):
             errors.append(f"{path.relative_to(ROOT)}: unresolved merge marker {marker}")
-    for raw_destination in LINK.findall("\n".join(unfenced_lines(text))):
+    link_text = "\n".join(unfenced_lines(text))
+    link_text = CODE_SPAN.sub(" ", link_text)
+    for raw_destination in LINK.findall(link_text):
         destination, fragment = destination_parts(raw_destination)
         if not destination and not fragment:
             continue


### PR DESCRIPTION
## Summary

Fix documentation link validation so Markdown link syntax shown inside matched, same-line inline code spans is ignored while real links remain checked.

## Changes

- Filter fenced examples first, then mask matched inline code spans only in the derived text used for link validation.
- Reuse the existing inline-code expression and replace spans with a space so surrounding text cannot be joined into a synthetic link.
- Add regressions for one-, two-, and three-backtick spans, shorter backticks inside longer spans, adjacent real links, fragment joining, and unmatched backticks.
- Preserve merge-marker, heading, traversal, fragment, repository-owner, and existing fenced-code checks.

## Testing

Passed:

- `.venv/bin/pytest -q backend/tests/test_check_docs.py` — 21 passed.
- `.venv/bin/ruff check backend scripts`.
- `.venv/bin/ruff format --check backend scripts` — 30 files already formatted.
- `make lint`.
- `NODE_OPTIONS=--localstorage-file=/tmp/agent-me-review-119-localstorage make test` — 193 backend tests and 85 frontend tests passed.
- `make knowledge-check`.
- `make docs` — 52 Markdown files and 16 maintained lesson pages passed.
- `make evaluate` — 4/4 cases passed.
- `npm run build --prefix frontend` — production frontend build passed; 36 modules transformed.
- `git diff --check HEAD^ HEAD`.

Not run successfully:

- `make build` — unavailable because Docker 26.1.5 is installed without the Compose plugin (`docker: 'compose' is not a docker command`). The container build is therefore not validated.

## Course and translation impact

None. No course behavior, explanation, maintained translation, command, or documentation contract changed.

## Security and privacy impact

None. No secrets, `.env` contents, private documents, production prompts, database files, personal records, external calls, or new parsing dependencies are included. Authorization, retention, logging, and provider behavior are unchanged.

## Compatibility, migration, and rollback

No dependency, public API, schema, storage, migration, configuration, authorization, retention, logging, or provider changes are required. Rollback is the single commit in this pull request.

## Known limitations

This remains deliberately narrower than a full CommonMark parser. It does not add multiline code-span, reference-style link, HTML, or external URL crawling support. The Docker Compose container build could not be validated in the available environment, as noted above.

## Related Issue

Closes #119
