### PR TITLE
fix: clear stale clipboard feedback on answer changes

### DIFF
--- a/frontend/src/AnswerResult.test.tsx
+++ b/frontend/src/AnswerResult.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AnswerResult } from "./AnswerResult";
+import type { ChatResponse, CollaborationResponse } from "./api";
+import { messages } from "./i18n";
+
+const text = messages.en;
+
+const syntheticResultA: ChatResponse = {
+  answer: "First synthetic answer.",
+  mode: "extractive",
+  sources: [
+    { title: "First doc", path: "first.md", excerpt: "First excerpt.", score: 1 },
+  ],
+};
+
+const syntheticResultB: ChatResponse = {
+  answer: "Second synthetic answer.",
+  mode: "openai-compatible",
+  sources: [
+    { title: "Second doc", path: "second.md", excerpt: "Second excerpt.", score: 0.8 },
+  ],
+};
+
+const syntheticCollaboration: CollaborationResponse = {
+  run_id: "run_synthetic_1234567890abcdef12345678",
+  workflow: "planner-researcher-critic-writer",
+  mode: "multi-agent-local",
+  answer: "Collaboration answer.",
+  grounded: true,
+  sources: [
+    { title: "Collab doc", path: "collab.md", excerpt: "Collab excerpt.", score: 0.9 },
+  ],
+  trace: [],
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+it("clears success clipboard feedback when the result changes", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  const { rerender } = render(<AnswerResult result={syntheticResultA} text={text} />);
+
+  await userEvent.click(screen.getByRole("button", { name: text.copyAnswer }));
+  expect(writeText).toHaveBeenCalledWith("First synthetic answer.");
+  expect(await screen.findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+
+  rerender(<AnswerResult result={syntheticResultB} text={text} />);
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  expect(screen.getByText("Second synthetic answer.")).toBeInTheDocument();
+});
+
+it("clears failure clipboard feedback when the result changes", async () => {
+  const writeText = vi.fn().mockRejectedValue(new DOMException("denied", "NotAllowedError"));
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  const { rerender } = render(<AnswerResult result={syntheticResultA} text={text} />);
+
+  await userEvent.click(screen.getByRole("button", { name: text.copyAnswer }));
+  const status = await screen.findByRole("status");
+  expect(status).toHaveTextContent(text.copyFailure);
+
+  rerender(<AnswerResult result={syntheticResultB} text={text} />);
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});
+
+it("clears sources copy feedback when the result changes", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  const { rerender } = render(<AnswerResult result={syntheticResultA} text={text} />);
+
+  await userEvent.click(screen.getByRole("button", { name: text.copySources }));
+  expect(writeText).toHaveBeenCalledWith("First doc — first.md");
+  expect(await screen.findByRole("status")).toHaveTextContent(text.copySourcesSuccess);
+
+  rerender(<AnswerResult result={syntheticResultB} text={text} />);
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});
+
+it("preserves clipboard feedback when an unrelated parent rerender keeps the same result", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  const { rerender } = render(
+    <AnswerResult result={syntheticResultA} text={text} headingLevel={2} />,
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: text.copyAnswer }));
+  expect(await screen.findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+
+  // Rerender with the same result reference but changed heading level
+  rerender(<AnswerResult result={syntheticResultA} text={text} headingLevel={3} />);
+  expect(screen.getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+  expect(screen.getByRole("heading", { name: text.answer, level: 3 })).toBeInTheDocument();
+
+  // Rerender with equivalent cloned data
+  rerender(
+    <AnswerResult
+      result={{
+        ...syntheticResultA,
+        sources: [...syntheticResultA.sources],
+      }}
+      text={text}
+      headingLevel={3}
+    />,
+  );
+  expect(screen.getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+});
+
+it("maintains independent copy statuses across multiple AnswerResult instances", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  function MultiResult({ first, second }: { first: ChatResponse; second: CollaborationResponse }) {
+    return (
+      <div>
+        <div data-testid="card-1">
+          <AnswerResult result={first} text={text} headingLevel={3} />
+        </div>
+        <div data-testid="card-2">
+          <AnswerResult result={second} text={text} headingLevel={4} />
+        </div>
+      </div>
+    );
+  }
+
+  const { rerender } = render(
+    <MultiResult first={syntheticResultA} second={syntheticCollaboration} />,
+  );
+
+  const card1 = screen.getByTestId("card-1");
+  const card2 = screen.getByTestId("card-2");
+
+  await userEvent.click(within(card1).getByRole("button", { name: text.copyAnswer }));
+  expect(await within(card1).findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+  expect(within(card2).queryByRole("status")).not.toBeInTheDocument();
+
+  await userEvent.click(within(card2).getByRole("button", { name: text.copyAnswer }));
+  expect(await within(card2).findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+  expect(within(card1).getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+
+  // Updating card 1 clears only card 1's status, leaving card 2 independent
+  rerender(<MultiResult first={syntheticResultB} second={syntheticCollaboration} />);
+  expect(within(card1).queryByRole("status")).not.toBeInTheDocument();
+  expect(within(card2).getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+});
+
+it("does not apply in-flight clipboard feedback to a replaced result", async () => {
+  let resolveClipboard!: () => void;
+  const writePromise = new Promise<void>((resolve) => {
+    resolveClipboard = resolve;
+  });
+  const writeText = vi.fn().mockReturnValue(writePromise);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  const { rerender } = render(<AnswerResult result={syntheticResultA} text={text} />);
+
+  // Trigger copy while writeText is unresolved
+  await userEvent.click(screen.getByRole("button", { name: text.copyAnswer }));
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+  // Replace result before clipboard promise finishes
+  rerender(<AnswerResult result={syntheticResultB} text={text} />);
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+  // Complete the in-flight clipboard write
+  resolveClipboard();
+  await Promise.resolve();
+
+  // The status must NOT be applied to resultB
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});

--- a/frontend/src/AnswerResult.tsx
+++ b/frontend/src/AnswerResult.tsx
@@ -7,12 +7,47 @@ function formatSourcesForCopy(sources: readonly { title: string; path: string }[
   return sources.map((source) => `${source.title} — ${source.path}`).join("\n");
 }
 
+function isSameResult(
+  a: ChatResponse | CollaborationResponse,
+  b: ChatResponse | CollaborationResponse,
+): boolean {
+  if (a === b) return true;
+  if (a.answer !== b.answer || a.mode !== b.mode) return false;
+  if ("run_id" in a || "run_id" in b) {
+    if (!("run_id" in a && "run_id" in b && a.run_id === b.run_id)) {
+      return false;
+    }
+  }
+  if (a.sources.length !== b.sources.length) return false;
+  return a.sources.every(
+    (source, index) =>
+      source.path === b.sources[index].path &&
+      source.excerpt === b.sources[index].excerpt &&
+      source.title === b.sources[index].title,
+  );
+}
+
 export function AnswerResult({ result, text, headingLevel = 2 }: {
   result: ChatResponse | CollaborationResponse;
   text: Messages;
   headingLevel?: 2 | 3 | 4;
 }) {
-  const [copyStatus, setCopyStatus] = useState("");
+  const [copyFeedback, setCopyFeedback] = useState<{
+    result: ChatResponse | CollaborationResponse;
+    status: string;
+  } | null>(null);
+  const [prevResult, setPrevResult] = useState(result);
+
+  if (prevResult !== result) {
+    setPrevResult(result);
+    if (!isSameResult(prevResult, result)) {
+      setCopyFeedback(null);
+    }
+  }
+
+  const copyStatus =
+    copyFeedback && isSameResult(copyFeedback.result, result) ? copyFeedback.status : "";
+
   const Heading = headingLevel === 4 ? "h4" : headingLevel === 3 ? "h3" : "h2";
   const DetailHeading = headingLevel === 4 ? "h5" : headingLevel === 3 ? "h4" : "h3";
 
@@ -20,9 +55,9 @@ export function AnswerResult({ result, text, headingLevel = 2 }: {
     try {
       if (!navigator.clipboard?.writeText) throw new Error("clipboard unavailable");
       await navigator.clipboard.writeText(value);
-      setCopyStatus(successMessage);
+      setCopyFeedback({ result, status: successMessage });
     } catch {
-      setCopyStatus(text.copyFailure);
+      setCopyFeedback({ result, status: text.copyFailure });
     }
   }
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -481,6 +481,50 @@ it("shows a safe localized message when the clipboard write fails", async () => 
   expect(status.textContent).not.toMatch(/NotAllowedError|denied/);
 });
 
+it("clears stale clipboard feedback when a subsequent question returns a new answer", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  let requestCount = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith("/api/v1/profile")) return Promise.resolve(profileResponse);
+      requestCount += 1;
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          answer: requestCount === 1 ? "First answer." : "Second answer.",
+          mode: "extractive",
+          sources: [],
+        }),
+      });
+    }),
+  );
+
+  render(<App />);
+  const input = screen.getByLabelText(/ask the example/i);
+  await userEvent.type(input, "First question");
+  await userEvent.click(screen.getByRole("button", { name: "Ask" }));
+  await screen.findByText("First answer.", { selector: ".answer > p" });
+
+  await userEvent.click(screen.getByRole("button", { name: "Copy answer" }));
+  expect(await screen.findByRole("status")).toHaveTextContent("Answer copied to clipboard.");
+
+  // Unrelated re-render caused by typing next question preserves feedback
+  await userEvent.clear(input);
+  await userEvent.type(input, "Second question");
+  expect(screen.getByRole("status")).toHaveTextContent("Answer copied to clipboard.");
+
+  // Submitting second question and rendering new answer clears stale clipboard feedback
+  await userEvent.click(screen.getByRole("button", { name: "Ask" }));
+  await screen.findByText("Second answer.", { selector: ".answer > p" });
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});
+
 it("exports only the validated collaboration response and revokes its object URL", () => {
   let blobParts: BlobPart[] = [];
   const createObjectURL = vi.fn(() => "blob:run");

--- a/frontend/src/WorkflowComparison.test.tsx
+++ b/frontend/src/WorkflowComparison.test.tsx
@@ -215,3 +215,29 @@ it("disables comparison for empty questions and aborts its requests when unmount
   unmount();
   await waitFor(() => expect(requests.every(([, init]) => init?.signal?.aborted)).toBe(true));
 });
+
+it("maintains independent clipboard statuses between comparison sides", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  mockRequests(async (policy) => response(fixtures[policy]));
+  render(<App />);
+  await userEvent.type(screen.getByLabelText(text.formLabel), question);
+  await userEvent.click(screen.getByRole("button", { name: text.compareWorkflows }));
+  await screen.findByText(verified.run_id);
+
+  const baselineCard = screen.getByRole("article", { name: text.baselineComparison });
+  const verifiedCard = screen.getByRole("article", { name: text.verifiedComparison });
+
+  await userEvent.click(within(baselineCard).getByRole("button", { name: text.copyAnswer }));
+  expect(await within(baselineCard).findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+  expect(within(verifiedCard).queryByRole("status")).not.toBeInTheDocument();
+
+  await userEvent.click(within(verifiedCard).getByRole("button", { name: text.copyAnswer }));
+  expect(await within(verifiedCard).findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+  expect(within(baselineCard).getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+});
+


### PR DESCRIPTION
## Problem and scope

Fixes the stale clipboard status shown in `AnswerResult` when a new answer replaces the previous result.

Closes #118

## What changed

* Clear clipboard success/failure feedback when the displayed result changes.
* Preserve clipboard feedback when the same result is re-rendered.
* Prevent an in-flight clipboard operation from showing feedback for a newer result.
* Keep clipboard status independent across multiple `AnswerResult` instances.
* Added regression tests covering answer copy, source copy, failure feedback, rerenders, multiple instances, and replaced results.

## Verification evidence

The following frontend checks were run:

* `npm test -- src/App.test.tsx src/WorkflowComparison.test.tsx` — 32/32 tests passed
* `npm run lint` — passed with 0 errors and 0 warnings
* `npm run typecheck` — passed with 0 errors
* `npm test` — 10/10 test files, 93/93 tests passed
* `npm run build` — passed

Relevant output, screenshots, or evaluation case counts:

* 93/93 frontend tests passed.
* No screenshots required; this is a behavioral/accessibility fix.

## Course and translation impact

* [x] No course behavior or explanation changed.
* [ ] English course/docs were updated.
* [ ] Maintained translations were updated or a follow-up issue is linked.
* [ ] New commands and links were run/checked.

Translation/review status:

No translation changes required.

## Security and privacy impact

* [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
* [x] Untrusted text remains safely rendered and bounded.
* [x] Authorization, retention, logging, and external-provider impact were considered where relevant.

Describe impact or write `none`:

None. The change only manages local clipboard feedback state in the frontend.

## Compatibility, migration, and rollback

No public API, schema, or migration changes.

Rollback can be performed by reverting commit `62425b7`.

## Known limitations

* No changes were made to clipboard permission behavior or clipboard UX beyond clearing stale feedback when the displayed result changes.
