### PR TITLE
fix: reset clipboard feedback for every new result instance

### DIFF
--- a/frontend/src/AnswerResult.test.tsx
+++ b/frontend/src/AnswerResult.test.tsx
@@ -114,8 +114,20 @@ it("preserves clipboard feedback when an unrelated parent rerender keeps the sam
   rerender(<AnswerResult result={syntheticResultA} text={text} headingLevel={3} />);
   expect(screen.getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
   expect(screen.getByRole("heading", { name: text.answer, level: 3 })).toBeInTheDocument();
+});
 
-  // Rerender with equivalent cloned data
+it("clears clipboard feedback when an equivalent new result replaces the current one", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+
+  const { rerender } = render(<AnswerResult result={syntheticResultA} text={text} />);
+
+  await userEvent.click(screen.getByRole("button", { name: text.copyAnswer }));
+  expect(await screen.findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+
   rerender(
     <AnswerResult
       result={{
@@ -126,7 +138,7 @@ it("preserves clipboard feedback when an unrelated parent rerender keeps the sam
       headingLevel={3}
     />,
   );
-  expect(screen.getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
 });
 
 it("maintains independent copy statuses across multiple AnswerResult instances", async () => {

--- a/frontend/src/AnswerResult.tsx
+++ b/frontend/src/AnswerResult.tsx
@@ -7,26 +7,6 @@ function formatSourcesForCopy(sources: readonly { title: string; path: string }[
   return sources.map((source) => `${source.title} — ${source.path}`).join("\n");
 }
 
-function isSameResult(
-  a: ChatResponse | CollaborationResponse,
-  b: ChatResponse | CollaborationResponse,
-): boolean {
-  if (a === b) return true;
-  if (a.answer !== b.answer || a.mode !== b.mode) return false;
-  if ("run_id" in a || "run_id" in b) {
-    if (!("run_id" in a && "run_id" in b && a.run_id === b.run_id)) {
-      return false;
-    }
-  }
-  if (a.sources.length !== b.sources.length) return false;
-  return a.sources.every(
-    (source, index) =>
-      source.path === b.sources[index].path &&
-      source.excerpt === b.sources[index].excerpt &&
-      source.title === b.sources[index].title,
-  );
-}
-
 export function AnswerResult({ result, text, headingLevel = 2 }: {
   result: ChatResponse | CollaborationResponse;
   text: Messages;
@@ -36,17 +16,7 @@ export function AnswerResult({ result, text, headingLevel = 2 }: {
     result: ChatResponse | CollaborationResponse;
     status: string;
   } | null>(null);
-  const [prevResult, setPrevResult] = useState(result);
-
-  if (prevResult !== result) {
-    setPrevResult(result);
-    if (!isSameResult(prevResult, result)) {
-      setCopyFeedback(null);
-    }
-  }
-
-  const copyStatus =
-    copyFeedback && isSameResult(copyFeedback.result, result) ? copyFeedback.status : "";
+  const copyStatus = copyFeedback?.result === result ? copyFeedback.status : "";
 
   const Heading = headingLevel === 4 ? "h4" : headingLevel === 3 ? "h3" : "h2";
   const DetailHeading = headingLevel === 4 ? "h5" : headingLevel === 3 ? "h4" : "h3";

--- a/frontend/src/WorkflowComparison.test.tsx
+++ b/frontend/src/WorkflowComparison.test.tsx
@@ -240,4 +240,3 @@ it("maintains independent clipboard statuses between comparison sides", async ()
   expect(await within(verifiedCard).findByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
   expect(within(baselineCard).getByRole("status")).toHaveTextContent(text.copyAnswerSuccess);
 });
-


### PR DESCRIPTION
## Summary

Follow-up to #124. A distinct answer result can contain the same answer, mode, and sources as the previous response. Treating those payloads as equal preserves stale clipboard feedback even though the parent supplied a genuinely new result.

- key clipboard feedback to the exact result instance
- preserve feedback for unrelated rerenders that reuse that instance
- suppress late clipboard completions for replaced results
- cover equivalent-but-distinct result objects
- remove the added trailing blank line flagged by `git diff --check`

## Verification

- `npm test -- src/AnswerResult.test.tsx src/App.test.tsx src/WorkflowComparison.test.tsx` — 39/39 passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm test` — 94/94 passed
- `npm run build` — passed
- `git diff --check` — passed