### PR TITLE
fix: restore missing personal workspace scaffolding

### DIFF
--- a/backend/tests/test_init_personal.py
+++ b/backend/tests/test_init_personal.py
@@ -1,0 +1,80 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "init_personal.py"
+
+
+def load_init_personal():
+    spec = spec_from_file_location("init_personal", SCRIPT)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_init_personal_restores_missing_scaffolding(tmp_path, monkeypatch):
+    init_personal = load_init_personal()
+    monkeypatch.setattr(init_personal, "ROOT", tmp_path)
+
+    init_personal.main()
+
+    private = tmp_path / "private"
+    env = private / "personal.env"
+    knowledge = private / "knowledge"
+    profile = private / "profile-template.json"
+
+    original_env = env.read_bytes()
+    original_profile = profile.read_bytes()
+
+    knowledge.rmdir()
+    profile.unlink()
+
+    init_personal.main()
+
+    assert env.read_bytes() == original_env
+    assert knowledge.is_dir()
+    assert profile.read_bytes() == original_profile
+
+
+def test_init_personal_does_not_overwrite_existing_files(tmp_path, monkeypatch):
+    init_personal = load_init_personal()
+    monkeypatch.setattr(init_personal, "ROOT", tmp_path)
+
+    init_personal.main()
+
+    private = tmp_path / "private"
+    env = private / "personal.env"
+    profile = private / "profile-template.json"
+    database = private / "twin.sqlite3"
+    knowledge_file = private / "knowledge" / "notes.md"
+
+    original_env = env.read_bytes()
+
+    profile.write_text("my own profile", encoding="utf-8")
+    database.write_bytes(b"my database")
+    knowledge_file.write_text("my notes", encoding="utf-8")
+
+    init_personal.main()
+
+    assert env.read_bytes() == original_env
+    assert profile.read_text(encoding="utf-8") == "my own profile"
+    assert database.read_bytes() == b"my database"
+    assert knowledge_file.read_text(encoding="utf-8") == "my notes"
+
+
+def test_init_personal_reports_created_and_no_changes(tmp_path, monkeypatch, capsys):
+    init_personal = load_init_personal()
+    monkeypatch.setattr(init_personal, "ROOT", tmp_path)
+
+    init_personal.main()
+
+    first_output = capsys.readouterr().out
+
+    assert "private/personal.env" in first_output
+    assert "private/knowledge/" in first_output
+    assert "private/profile-template.json" in first_output
+
+    init_personal.main()
+
+    second_output = capsys.readouterr().out
+
+    assert second_output.strip() == "Workspace already exists; no files changed."

--- a/docs/PERSONAL.md
+++ b/docs/PERSONAL.md
@@ -25,7 +25,7 @@ npm run dev -- --host 127.0.0.1
 粘贴到“我的 AI 分身”的密钥输入框。密钥只保存在当前页面内存中，刷新后重新解锁。
 Windows 可使用 `.venv\Scripts\uvicorn.exe` 和 `python` 替换对应命令。
 
-初始化脚本不覆盖已有工作区，也不修改 `.env`。`private/personal.env` 由启动命令显式加载，
+初始化脚本具有幂等性：保留已有工作区数据和 `.env`，同时重新创建缺失的非敏感基础文件。
 不使用该命令时私有模式默认关闭。已有 `.env` 中的模型配置仍然有效。
 
 ### 2. 填写档案
@@ -98,7 +98,7 @@ git diff --cached
 This is an opt-in, single-owner local workspace. Install the dependencies using the
 [repository quick start](../README.md#quick-start), then run the initialization and launch commands above.
 Unlock the new panel using `PERSONAL_TOKEN` from `private/personal.env`.
-The initializer is idempotent and never overwrites an existing workspace or `.env`.
+The initializer is idempotent: it preserves existing workspace data and `.env`, while recreating any missing non-secret scaffolding.
 
 Add profile fields as typed entries (`fact`, `preference`, `event`, `decision`). All new or edited
 entries are pending until confirmed. Use `Remember: ...` in private chat to propose a preference,

--- a/scripts/init_personal.py
+++ b/scripts/init_personal.py
@@ -11,38 +11,52 @@ ROOT = Path(__file__).resolve().parents[1]
 def main():
     private = ROOT / "private"
     private.mkdir(mode=0o700, exist_ok=True)
-    (private / "knowledge").mkdir(mode=0o700, exist_ok=True)
+    created = []
+
+    knowledge = private / "knowledge"
+    if not knowledge.exists():
+        knowledge.mkdir(mode=0o700)
+        created.append("private/knowledge/")
     env = private / "personal.env"
-    if env.exists():
+    if not env.exists():
+        token = secrets.token_urlsafe(32)
+        env.write_text(
+            "PERSONAL_ENABLED=true\n"
+            f"PERSONAL_DATA_DIR={json.dumps(str(private))}\n"
+            f"PERSONAL_TOKEN={token}\n",
+            encoding="utf-8",
+        )
+        env.chmod(0o600)
+        created.append("private/personal.env")
+
+    profile = private / "profile-template.json"
+    if not profile.exists():
+        profile.write_text(
+            json.dumps(
+                {
+                    "kind": "fact",
+                    "key": "identity.name",
+                    "content": "Replace with your name",
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        created.append("private/profile-template.json")
+
+    if created:
+        print("Created:")
+        for path in created:
+            print(f"- {path}")
+        print(
+            "Read PERSONAL_TOKEN in private/personal.env to unlock the browser workspace."
+        )
+        print(
+            "Run: .venv/bin/uvicorn app.main:app --app-dir backend --env-file private/personal.env "
+            "--host 127.0.0.1 --port 8000"
+        )
+    else:
         print("Workspace already exists; no files changed.")
-        return
-    token = secrets.token_urlsafe(32)
-    env.write_text(
-        "PERSONAL_ENABLED=true\n"
-        f"PERSONAL_DATA_DIR={json.dumps(str(private))}\n"
-        f"PERSONAL_TOKEN={token}\n",
-        encoding="utf-8",
-    )
-    env.chmod(0o600)
-    (private / "profile-template.json").write_text(
-        json.dumps(
-            {
-                "kind": "fact",
-                "key": "identity.name",
-                "content": "Replace with your name",
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    print("Created private/personal.env and private/profile-template.json.")
-    print(
-        "Read PERSONAL_TOKEN in private/personal.env to unlock the browser workspace."
-    )
-    print(
-        "Run: .venv/bin/uvicorn app.main:app --app-dir backend --env-file private/personal.env "
-        "--host 127.0.0.1 --port 8000"
-    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the idempotency issue in `scripts/init_personal.py` where an existing `private/personal.env` caused the initializer to return early and leave missing non-secret workspace scaffolding unrecreated.

## What changed

* Preserve an existing `private/personal.env` byte-for-byte, including the existing token.
* Recreate `private/knowledge/` when it is missing.
* Recreate `private/profile-template.json` when it is missing.
* Never overwrite existing profile, database, or knowledge files.
* Report which paths were created when missing scaffolding is restored.
* Keep the existing no-change message when the workspace is already fully initialized.
* Added focused regression tests using a temporary root.
* Updated `docs/PERSONAL.md` to document the idempotent initializer behavior.

## Verification evidence

The following backend checks were run:

* `uv run --directory backend pytest -q tests/test_init_personal.py` — **3/3 tests passed**
* `uv run --directory backend ruff check ../scripts/init_personal.py tests/test_init_personal.py` — **passed with 0 errors**
* `uv run --directory backend ruff format --check ../scripts/init_personal.py tests/test_init_personal.py` — **2 files already formatted**
* `git diff --cached --check` — **passed**

Full backend test suite:

* `uv run --directory backend pytest -q` — **194 passed, 1 skipped, 1 failed**
* The failure is in `tests/test_check_knowledge.py`, where Windows denied creation of a symbolic link with `WinError 1314` (`A required privilege is not held by the client`).
* This failure is unrelated to the personal initializer changes.

Relevant output, screenshots, or evaluation case counts:

* 3/3 focused regression tests passed.
* No screenshots required; this is a local initializer/idempotency fix.

## Course and translation impact

* No course behavior or explanations changed.
* `docs/PERSONAL.md` was updated to document the initializer's idempotent behavior.
* No translation changes were required.

Translation/review status:

No translation changes required.

## Security and privacy impact

* No secrets, `.env` contents, private documents, database files, or personal records are included.
* Existing `PERSONAL_TOKEN` values are preserved and are never regenerated or printed by a rerun.
* Existing profile, database, and knowledge files are never overwritten or deleted.
* Tests use a temporary root and never modify the real `private/` workspace.

Describe impact or write `none`:

None. The change only restores missing non-secret local workspace scaffolding while preserving existing personal data and secrets.

## Compatibility, migration, and rollback

No public API, schema, dependency, or database migration changes.

The existing personal workspace layout remains compatible.

Rollback can be performed by reverting commit `3790af6`.

## Known limitations

* The complete backend test suite could not be completed successfully on this Windows environment because an unrelated symlink test requires a Windows privilege that is not currently available.
* Repository-wide Ruff also reports five pre-existing lint errors in unrelated scripts; no unrelated files were modified as part of this fix.
* No changes were made to token generation behavior when `private/personal.env` already exists.

**Commit:** `3790af6` — `fix: restore missing personal workspace scaffolding`
