### PR TITLE
fix: recognize valid indented ATX headings as document titles

### DIFF
--- a/backend/app/knowledge.py
+++ b/backend/app/knowledge.py
@@ -84,10 +84,14 @@ def _query_tokens(value: str) -> set[str]:
     return normalized_tokens(value) - _STOP_WORDS
 
 
+_H1_HEADING = re.compile(r"^\s{0,3}#\s+(.*?)(?:\s+#+)?\s*$")
+
+
 def _title(path: Path, text: str) -> str:
     for line in text.splitlines():
-        if line.startswith("# "):
-            return line[2:].strip()
+        match = _H1_HEADING.match(line)
+        if match:
+            return match.group(1).strip()
     return path.stem.replace("-", " ").replace("_", " ").title()
 
 

--- a/backend/tests/test_knowledge.py
+++ b/backend/tests/test_knowledge.py
@@ -293,3 +293,18 @@ def test_concurrent_document_reads_publish_one_consistent_cache(tmp_path: Path) 
 
     assert all([document.path for document in result] == ["profile.md"] for result in results)
     assert len({id(result[0]) for result in results}) == 1
+
+
+def test_title_extraction_from_atx_h1() -> None:
+    from pathlib import Path
+
+    from app.knowledge import _title
+
+    assert _title(Path("fallback.md"), "   # Valid Indented H1  ") == "Valid Indented H1"
+    assert (
+        _title(Path("fallback.md"), "# Heading with trailing hashes ###")
+        == "Heading with trailing hashes"
+    )
+    assert _title(Path("fallback.md"), "## H2 is ignored\n# Valid H1") == "Valid H1"
+    assert _title(Path("fallback.md"), "    # Four spaces is not H1\n# Valid H1") == "Valid H1"
+    assert _title(Path("fallback.md"), "No heading") == "Fallback"


### PR DESCRIPTION
Fixes #129.

Updates \_title()\ in \ackend/app/knowledge.py\ to use consistent ATX-heading parsing for document titles. 

- Zero-to-three-space-indented H1 headings are recognized.
- Optional closing hash sequences are excluded from the title.
- H2–H6 headings are not selected as document titles.
- More than three leading spaces does not become an ATX title.
- The first valid H1 wins; otherwise the existing filename fallback remains.
- Added tests to cover these boundaries.