### PR TITLE
fix(knowledge): recognize indented ATX headings with optional closing hashes in document titles

### DIFF
--- a/backend/app/knowledge.py
+++ b/backend/app/knowledge.py
@@ -80,14 +80,18 @@ class _KnowledgeFile:
     changed_ns: int
 
 
+_H1_HEADING = re.compile(r"^\s{0,3}#\s+(.+?)(?:\s+#+)?$")
+
+
 def _query_tokens(value: str) -> set[str]:
     return normalized_tokens(value) - _STOP_WORDS
 
 
 def _title(path: Path, text: str) -> str:
     for line in text.splitlines():
-        if line.startswith("# "):
-            return line[2:].strip()
+        match = _H1_HEADING.match(line)
+        if match:
+            return match.group(1).strip()
     return path.stem.replace("-", " ").replace("_", " ").title()
 
 

--- a/backend/tests/test_knowledge.py
+++ b/backend/tests/test_knowledge.py
@@ -293,3 +293,40 @@ def test_concurrent_document_reads_publish_one_consistent_cache(tmp_path: Path) 
 
     assert all([document.path for document in result] == ["profile.md"] for result in results)
     assert len({id(result[0]) for result in results}) == 1
+
+
+@pytest.mark.parametrize(
+    ("markdown", "expected_title"),
+    [
+        ("# Simple\n\nBody", "Simple"),
+        ("  # Indented Two Spaces\n\nBody", "Indented Two Spaces"),
+        ("   # Indented Three Spaces\n\nBody", "Indented Three Spaces"),
+        ("# Trailing Hashes ##\n\nBody", "Trailing Hashes"),
+        ("  # Indented With Closing ###\n\nBody", "Indented With Closing"),
+        ("#  Extra   Whitespace  \n\nBody", "Extra   Whitespace"),
+    ],
+)
+def test_title_recognizes_indented_atx_headings(
+    tmp_path: Path, markdown: str, expected_title: str
+) -> None:
+    (tmp_path / "doc.md").write_text(markdown, encoding="utf-8")
+    documents = KnowledgeBase(str(tmp_path)).documents()
+    assert documents[0].title == expected_title
+
+
+def test_title_rejects_more_than_three_leading_spaces(tmp_path: Path) -> None:
+    (tmp_path / "doc.md").write_text("    # Not A Heading\n\nBody", encoding="utf-8")
+    documents = KnowledgeBase(str(tmp_path)).documents()
+    assert documents[0].title == "Doc"
+
+
+def test_title_selects_h1_over_h2(tmp_path: Path) -> None:
+    (tmp_path / "doc.md").write_text("## Subtitle\n\n# Real Title\n\nBody", encoding="utf-8")
+    documents = KnowledgeBase(str(tmp_path)).documents()
+    assert documents[0].title == "Real Title"
+
+
+def test_title_falls_back_to_filename_when_no_h1(tmp_path: Path) -> None:
+    (tmp_path / "my-document_file.md").write_text("## Only H2\n\nBody", encoding="utf-8")
+    documents = KnowledgeBase(str(tmp_path)).documents()
+    assert documents[0].title == "My Document File"


### PR DESCRIPTION
## Summary

Closes #129

The `_title()` function in `backend/app/knowledge.py` previously only matched lines starting exactly with `# `, missing valid CommonMark ATX headings that are indented by 1-3 spaces or have optional closing hash sequences (e.g., `  # Title ##`).

This caused source cards to show a less useful filename-based title even when the document contained a valid indented H1.

## What changed

- Added `_H1_HEADING` regex: `^\s{0,3}#\s+(.+?)(?:\s+#+)?$`
- `_title()` now uses regex matching instead of `str.startswith("# ")`
- The first valid H1 wins; otherwise the existing filename fallback remains

## Test coverage

9 new parametrized tests covering all acceptance criteria from the issue:

- Simple H1 (`# Title`)
- Indented by 2 and 3 spaces (`  # Title`, `   # Title`)
- Trailing hashes (`# Title ##`)
- Indented with closing hashes (`  # Title ###`)
- Extra whitespace inside title text
- Rejection of 4+ leading spaces (code block, not heading)
- H1 selected over H2 when H2 appears first
- Filename fallback when no H1 exists

## Verification

```bash
cd backend && python -m pytest tests/test_knowledge.py -v
# 34 passed
```

## Out of scope (per issue)

Setext headings, YAML front matter, changing retrieval scoring, and adding a Markdown parser dependency.
