### PR TITLE
fix(contracts): enforce normalized source scores

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -44,7 +44,7 @@ class Source(BaseModel):
     title: str
     path: str
     excerpt: str
-    score: float
+    score: float = Field(ge=0, le=1, allow_inf_nan=False)
 
 
 class ChatResponse(BaseModel):

--- a/backend/tests/test_source_scores.py
+++ b/backend/tests/test_source_scores.py
@@ -1,0 +1,54 @@
+"""Keep normalized source scores consistent across public response models."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas import ChatResponse, CollaborationResponse, Source
+
+FIXTURES = (
+    Path(__file__).resolve().parents[2] / "frontend" / "src" / "__fixtures__" / "collaboration"
+)
+
+
+@pytest.fixture(params=["source", "chat", "baseline", "verified"])
+def source_contract(request):
+    fixture = "verified" if request.param == "verified" else "baseline"
+    payload = json.loads((FIXTURES / f"{fixture}.json").read_text(encoding="utf-8"))
+    source = payload["sources"][0]
+    if request.param == "source":
+        return Source, source, source
+    if request.param == "chat":
+        return (
+            ChatResponse,
+            {"answer": "Synthetic answer", "mode": "extractive", "sources": [source]},
+            source,
+        )
+    return CollaborationResponse, payload, source
+
+
+@pytest.mark.parametrize("score", [0.0, 0.5, 1.0])
+def test_public_source_scores_accept_the_normalized_range(source_contract, score) -> None:
+    model, payload, source = source_contract
+    source["score"] = score
+
+    response = model.model_validate(payload)
+    validated_source = response if isinstance(response, Source) else response.sources[0]
+
+    assert validated_source.score == score
+    assert model.model_validate_json(response.model_dump_json()) == response
+
+
+@pytest.mark.parametrize("score", [-0.25, 1.5, float("nan"), float("inf"), float("-inf")])
+def test_public_source_scores_reject_out_of_range_and_nonfinite_values(
+    source_contract, score
+) -> None:
+    model, payload, source = source_contract
+    source["score"] = score
+
+    with pytest.raises(ValidationError) as error:
+        model.model_validate(payload)
+
+    assert error.value.errors()[0]["loc"][-1] == "score"

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,6 +38,12 @@ links, unreadable Markdown, a file larger than `MAX_DOCUMENT_BYTES`, more than
 readiness, chat, and collaboration return a safe `503` without exposing private paths or filenames.
 The response includes `answer`, `mode`, and grounding `sources`.
 
+Each source has `title`, `path`, `excerpt`, and a finite normalized relevance `score` in the
+inclusive range **0..1**. Both `0` and `1` are valid; negative values, values greater than `1`,
+NaN, and infinities are rejected. The backend response model and the browser's shared source
+validator enforce this range for both chat and collaboration responses. This score measures
+retrieval overlap, not answer confidence or factual correctness.
+
 The application rejects HTTP request bodies larger than `MAX_REQUEST_BODY_BYTES` with `413`, before JSON parsing. This applies both when `Content-Length` is present and when a body is streamed without it.
 
 ## `POST /api/v1/collaborate`
@@ -128,8 +134,10 @@ After a collaboration response, **Download sanitized run JSON** exports the resp
 without a version envelope. **Open run record** accepts these baseline and verified `.json` files
 up to **1 MiB (1,048,576 bytes)**. The browser checks the byte limit before reading or parsing, then
 uses the same `parseCollaborationResponse` validator as network responses. Unknown workflows,
-version envelopes/discriminators, invalid stage order, non-finite numbers, and malformed records
-are rejected rather than migrated or partially rendered.
+version envelopes/discriminators, invalid stage order, non-finite numbers, source scores outside
+the inclusive **0..1** range, and malformed records are rejected rather than migrated or partially
+rendered. Invalid source scores produce the existing safe `replayInvalid` error without exposing
+file contents or parser diagnostics.
 
 The imported answer, sources, run ID, stages, and metrics use the same plain-text result view as a
 live response, with a visible **Local replay — not a new run** label. A valid shape does not

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,7 +1,50 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApiError, ask, collaborate, loadProfile } from "./api";
+import baseline from "./__fixtures__/collaboration/baseline.json";
+import verified from "./__fixtures__/collaboration/verified.json";
 
 afterEach(() => vi.unstubAllGlobals());
+
+describe.each([
+  {
+    name: "chat",
+    request: () => ask("Synthetic question"),
+    payload: { answer: "Synthetic answer", mode: "extractive", sources: baseline.sources },
+    code: "invalid_response",
+  },
+  {
+    name: "baseline collaboration",
+    request: () => collaborate("Synthetic question"),
+    payload: baseline,
+    code: "invalid_trace",
+  },
+  {
+    name: "verified collaboration",
+    request: () => collaborate("Synthetic question", "verified"),
+    payload: verified,
+    code: "invalid_trace",
+  },
+])("$name source scores", ({ request, payload, code }) => {
+  it.each([0, 0.5, 1])("accepts the normalized score %s", async (score) => {
+    const response = {
+      ...payload,
+      sources: payload.sources.map((source) => ({ ...source, score })),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => response }));
+
+    await expect(request()).resolves.toEqual(response);
+  });
+
+  it.each([-0.25, 1.5, NaN, Infinity, -Infinity])("rejects the invalid score %s", async (score) => {
+    const response = {
+      ...payload,
+      sources: payload.sources.map((source) => ({ ...source, score })),
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => response }));
+
+    await expect(request()).rejects.toMatchObject({ status: 502, code });
+  });
+});
 
 it("returns a typed grounded response", async () => {
   const fetchMock = vi.fn().mockResolvedValue({

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -55,7 +55,9 @@ function isSource(value: unknown): value is Source {
     typeof source.path === "string" &&
     typeof source.excerpt === "string" &&
     typeof source.score === "number" &&
-    Number.isFinite(source.score)
+    Number.isFinite(source.score) &&
+    source.score >= 0 &&
+    source.score <= 1
   );
 }
 

--- a/frontend/src/importRun.test.ts
+++ b/frontend/src/importRun.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import baseline from "./__fixtures__/collaboration/baseline.json";
 import verified from "./__fixtures__/collaboration/verified.json";
 import { MAX_RUN_FILE_BYTES, readCollaborationRun } from "./importRun";
@@ -8,6 +8,34 @@ afterEach(() => vi.restoreAllMocks());
 it.each([baseline, verified])("reads the current $workflow export", async (payload) => {
   await expect(readCollaborationRun(new File([JSON.stringify(payload)], "run.json")))
     .resolves.toEqual(payload);
+});
+
+describe.each([baseline, verified])("source scores in $workflow replay", (fixture) => {
+  it.each([0, 0.5, 1])("accepts the normalized score %s", async (score) => {
+    const payload = {
+      ...fixture,
+      sources: fixture.sources.map((source) => ({ ...source, score })),
+    };
+
+    await expect(readCollaborationRun(new File([JSON.stringify(payload)], "run.json")))
+      .resolves.toEqual(payload);
+  });
+
+  it.each(["-0.25", "1.5", "NaN", "Infinity", "-Infinity", "1e400", "-1e400"])(
+    "rejects score %s with only the safe replay error",
+    async (score) => {
+      const payload = {
+        ...fixture,
+        answer: "Synthetic untrusted file content must not appear in the error",
+        sources: fixture.sources.map((source) => ({ ...source, score: "SCORE_PLACEHOLDER" })),
+      };
+      // Preserve overflow and non-JSON literals instead of JSON.stringify converting them to null.
+      const content = JSON.stringify(payload).replace('"SCORE_PLACEHOLDER"', score);
+
+      await expect(readCollaborationRun(new File([content], "untrusted-score.json")))
+        .rejects.toMatchObject({ code: "replayInvalid", message: "replayInvalid" });
+    },
+  );
 });
 
 const validJSON = JSON.stringify(baseline);


### PR DESCRIPTION
## Problem and scope

Closes #121.

Source relevance is a normalized overlap score, but the backend accepted arbitrary floats and the frontend accepted finite scores outside `0..1`. This change enforces the existing invariant at response-model, network-parser, and local-replay boundaries without changing retrieval or ranking.

## What changed

- Constrain `Source.score` with `Field(ge=0, le=1, allow_inf_nan=False)`.
- Add inclusive bounds to the frontend's shared source validator, used by chat and both collaboration workflows.
- Add 32 backend cases covering direct `Source`, `ChatResponse`, and baseline/verified `CollaborationResponse` validation and valid JSON round trips.
- Add 24 mocked-network cases and 20 local-file replay cases covering `0`, `0.5`, `1`, negative/greater-than-one values, NaN, infinities, and JSON numeric overflow where applicable.
- Assert invalid replay scores return only the existing safe `replayInvalid` message/code. Reuse existing synthetic collaboration fixtures without modifying them.
- Document the normalized score range and replay rejection behavior in `docs/API.md`.

## Verification evidence

Regression tests were added before the fix: 20 backend cases and 10 frontend cases failed against the original implementation; they pass with the fix.

- [x] `make lint`
- [x] `make test` — **229 backend tests and 138 frontend tests passed**.
- [x] `make docs` — 52 Markdown files and 16 maintained lesson pages passed.
- [x] `make evaluate` — baseline **4/4 passed**.
- [ ] `make build` — attempted, but Docker Hub token requests timed out while resolving the pinned Python/nginx base images; the local container build did not complete. The subsequent [CI container build and smoke tests](https://github.com/jzjzzzzzzz/agent-me/actions/runs/34319266351/job/102362214779) passed.

Additional commands run successfully:

- `.venv/bin/pytest -q backend/tests/test_source_scores.py backend/tests/test_collaboration_contract.py` — **38 passed**.
- `cd frontend && npm test -- src/api.test.ts src/importRun.test.ts src/collaborationContract.test.ts` — **76 passed**.
- `make knowledge-check` — valid synthetic example corpus.
- `.venv/bin/python scripts/evaluate_collaboration.py --workflow verified --json` — **4/4 passed**.
- `python3 scripts/check_private_data.py`.
- `cd frontend && npm run build`.
- `git diff --check`.

## Course and translation impact

- [x] No course behavior or explanation changed.
- [x] English course/docs were updated — API reference only.
- [ ] Maintained translations were updated or a follow-up issue is linked — not applicable; no localized UI strings or course lessons changed.
- [x] New commands and links were run/checked — documentation checks passed; no new commands or links added.

Translation/review status: no translation changes. The existing retrieval formula remains unchanged.

## Security and privacy impact

- [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
- [x] Untrusted text remains safely rendered and bounded.
- [x] Authorization, retention, logging, and external-provider impact were considered where relevant.

This strengthens validation of untrusted response/import metadata. Invalid imports retain the safe error boundary without reflecting filenames, source excerpts, file contents, or parser diagnostics. No authorization, storage, logging, or provider-routing changes.

## Compatibility, migration, and rollback

Valid source scores, including exactly `0` and `1`, remain accepted. Existing shared fixtures and API/replay response shapes are unchanged; no dependency, migration, or schema-version change is needed. Previously accepted malformed records containing out-of-range scores are intentionally rejected rather than clamped or migrated. Revert this focused commit if legitimate normalized responses regress.

## Known limitations

- A normalized score validates retrieval metadata, not answer confidence, authenticity, or factual correctness.
- The local container build could not complete due to the Docker Hub network timeout described above. CI subsequently completed the container build and both-service smoke tests successfully; all nine PR checks passed.
