### PR TITLE
test(api): cover cache policy edge cases

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -274,9 +274,11 @@ async def test_unrelated_responses_keep_their_cache_behavior(
 ) -> None:
     health = await client.get("/health")
     ready = await client.get("/ready")
+    profile = await client.get("/api/v1/profile")
 
     assert "cache-control" not in health.headers
     assert "cache-control" not in ready.headers
+    assert "cache-control" not in profile.headers
 
 
 @pytest.mark.anyio
@@ -376,6 +378,7 @@ async def test_question_total_limit_has_a_stable_error_code(
     assert response.status_code == 413
     assert response.json()["code"] == "question_too_large"
     assert isinstance(response.json()["detail"], str)
+    assert response.headers["cache-control"] == "no-store"
 
 
 @pytest.mark.anyio
@@ -400,14 +403,16 @@ async def test_history_total_limit_is_enforced(client: httpx.AsyncClient) -> Non
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("endpoint", ["/api/v1/chat", "/api/v1/collaborate"])
 async def test_declared_oversized_request_body_is_rejected_before_parsing(
     client: httpx.AsyncClient,
+    endpoint: str,
 ) -> None:
     settings = get_settings()
     original = settings.max_request_body_bytes
     settings.max_request_body_bytes = 1_024
     try:
-        response = await client.post("/api/v1/chat", json={"question": "x" * 2_048})
+        response = await client.post(endpoint, json={"question": "x" * 2_048})
     finally:
         settings.max_request_body_bytes = original
 
@@ -534,3 +539,4 @@ async def test_request_id_header_is_exposed_to_allowed_browser_origins(
     exposed = response.headers.get("access-control-expose-headers", "")
     assert "X-Request-ID" in exposed
     assert response.headers["access-control-allow-origin"] == origin
+

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -539,4 +539,3 @@ async def test_request_id_header_is_exposed_to_allowed_browser_origins(
     exposed = response.headers.get("access-control-expose-headers", "")
     assert "X-Request-ID" in exposed
     assert response.headers["access-control-allow-origin"] == origin
-

--- a/course/07-production-capstone/README.md
+++ b/course/07-production-capstone/README.md
@@ -324,4 +324,3 @@ LLMs” unless your implementation and tests demonstrate those exact properties.
 ---
 
 **Previous: [Lesson 06](../06-evaluation/README.md)** · **Return to [course home](../README.md)** · **Review the [rubric](../RUBRIC.md)**
-

--- a/course/07-production-capstone/README.md
+++ b/course/07-production-capstone/README.md
@@ -94,6 +94,10 @@ can exhaust database connections, memory, provider quota, or cost budget.
 Store structured codes and safe metrics by default. Define retention, deletion, tenant access, and
 redaction before persisting prompts or excerpts.
 
+HTTP cache policy is separate from server-side retention. The chat and collaboration endpoints send
+`Cache-Control: no-store` so dynamic answers are not stored by browsers or intermediaries. This does
+not delete server logs, traces, or stored knowledge, which require their own retention controls.
+
 ## Read the implementation
 
 Revisit the boundaries you may extend:
@@ -320,3 +324,4 @@ LLMs” unless your implementation and tests demonstrate those exact properties.
 ---
 
 **Previous: [Lesson 06](../06-evaluation/README.md)** · **Return to [course home](../README.md)** · **Review the [rubric](../RUBRIC.md)**
+

--- a/course/translations/zh-CN/07-production-capstone/README.md
+++ b/course/translations/zh-CN/07-production-capstone/README.md
@@ -183,4 +183,3 @@ make build
 ---
 
 **上一课：[第 06 课](../06-evaluation/README.md)** · **返回[中文课程首页](../README.md)** · **查看[评分标准](../RUBRIC.md)**
-

--- a/course/translations/zh-CN/07-production-capstone/README.md
+++ b/course/translations/zh-CN/07-production-capstone/README.md
@@ -50,6 +50,8 @@ Worker 原子 claim stage，幂等写输出，再 append event。
 - **背压：**限制排队、tenant 并发、provider 并发和输出大小，防止耗尽连接、内存、额度和费用。
 - **隐私：**默认保存结构化 code/metric；持久化 prompt 前定义保留、删除、tenant 权限与脱敏。
 
+HTTP 缓存策略与服务端保留策略相互独立。聊天和协作接口返回 `Cache-Control: no-store`，避免浏览器或中间代理缓存动态回答；这不会删除服务端日志、trace 或已存储知识，它们仍需要独立的保留控制。
+
 ## 阅读实现
 
 重新检查你可能扩展的边界：[`collaboration.py`](../../../../backend/app/collaboration.py) 的角色状态与顺序、[`main.py`](../../../../backend/app/main.py) 的进程内 HTTP 执行、[`request_limits.py`](../../../../backend/app/request_limits.py) 的接收限制、[`docker-compose.yml`](../../../../docker-compose.yml) 的进程拓扑，以及 [CI](../../../../.github/workflows/ci.yml) 的打包验证。
@@ -181,3 +183,4 @@ make build
 ---
 
 **上一课：[第 06 课](../06-evaluation/README.md)** · **返回[中文课程首页](../README.md)** · **查看[评分标准](../RUBRIC.md)**
+


### PR DESCRIPTION
Follow-up to #101; relates to #57.

## Problem and scope

The cache middleware was merged in #101. This follow-up adds only the complementary regression coverage and course documentation requested by the maintainer. It does not modify the existing cache middleware.

## What changed

- Verify that `/api/v1/profile` keeps its existing cache behavior.
- Assert `Cache-Control: no-store` for question-length rejections on both Q&A endpoints.
- Run the oversized-request-body regression test for both `/api/v1/chat` and `/api/v1/collaborate`.
- Explain in English and Simplified Chinese that HTTP no-store controls do not replace server-side retention controls.

## Verification evidence

- [x] `pytest -q tests/test_api.py` — 37 passed.
- [x] `ruff check app tests`
- [x] `ruff format --check app tests`
- [x] `python ../scripts/check_docs.py`
- [ ] `make lint` — not run.
- [ ] `make test` — not run.
- [ ] `make docs` — not run.
- [ ] `make evaluate` — not run.
- [ ] `make build` — not run.

The scoped test run emitted Python 3.14 / pytest-asyncio deprecation warnings, with no test failures.

## Course and translation impact

- [x] No course behavior or commands changed.
- [x] English course documentation updated.
- [x] Maintained Simplified Chinese translation updated.
- [x] No new commands were added.

Translation/review status: English and Simplified Chinese wording were updated together and checked with the documentation validator.

## Security and privacy impact

- [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
- [x] The change preserves the existing route-scoped privacy policy and does not add logging or retention behavior.
- [x] HTTP cache control is explicitly distinguished from server-side logs, traces, and knowledge retention.

## Compatibility, migration, and rollback

No public API or schema changes. No migration is required. Reverting this commit removes only the additional tests and documentation.