### PR TITLE
fix: validate personal profile metadata

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -221,6 +221,50 @@ it("validates public profile metadata", async () => {
   });
 });
 
+it.each([true, false])("accepts personal_enabled: %s", async (personalEnabled) => {
+  const profile = {
+    name: "My Agent",
+    description: "My description",
+    max_question_chars: 1200,
+    external_provider_enabled: false,
+    personal_enabled: personalEnabled,
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok: true, json: async () => profile }),
+  );
+
+  await expect(loadProfile()).resolves.toEqual(profile);
+});
+
+it.each([
+  ["string", "false"],
+  ["number", 0],
+  ["object", {}],
+  ["array", []],
+  ["null", null],
+  ["undefined", undefined],
+])("rejects a %s personal_enabled value", async (_type, personalEnabled) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "My Agent",
+        description: "My description",
+        max_question_chars: 1200,
+        external_provider_enabled: false,
+        personal_enabled: personalEnabled,
+      }),
+    }),
+  );
+
+  await expect(loadProfile()).rejects.toMatchObject({
+    status: 502,
+    code: "invalid_profile",
+  });
+});
+
 it("rejects a profile without an explicit provider disclosure flag", async () => {
   vi.stubGlobal(
     "fetch",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -97,7 +97,9 @@ function parseProfileResponse(value: unknown): ProfileResponse {
     typeof profile.max_question_chars !== "number" ||
     !Number.isInteger(profile.max_question_chars) ||
     profile.max_question_chars < 1 ||
-    typeof profile.external_provider_enabled !== "boolean"
+    typeof profile.external_provider_enabled !== "boolean" ||
+    (Object.hasOwn(profile, "personal_enabled") &&
+      typeof profile.personal_enabled !== "boolean")
   ) {
     throw new ApiError("Server returned an invalid profile.", 502, "invalid_profile");
   }


### PR DESCRIPTION
## Problem and scope

`parseProfileResponse()` trusted the runtime type of the optional `personal_enabled` field. A malformed truthy value such as the string `"false"` could therefore expose a misleading private-workspace control.

Closes #117

## What changed

- Validate every present `personal_enabled` value as a boolean while preserving omission for backward compatibility.
- Add synthetic parser tests for `true`, `false`, omission, and invalid string, number, object, array, `null`, and `undefined` values.
- Preserve the existing `invalid_profile` failure contract and all provider-disclosure/question-limit checks.

## Verification evidence

- [x] `make lint`
- [x] `make test`
- [x] `make docs`
- [x] `make evaluate`
- [x] `make build`

Relevant output, screenshots, or evaluation case counts:

- Backend: 230 tests passed.
- Frontend: 10 files / 146 tests passed.
- Scoped profile/App suite: 2 files / 62 tests passed.
- Collaboration evaluation: 4/4 passed.
- Knowledge and documentation checks passed; both container images built successfully.

## Course and translation impact

- [x] No course behavior or explanation changed.
- [ ] English course/docs were updated.
- [ ] Maintained translations were updated or a follow-up issue is linked.
- [ ] New commands and links were run/checked.

Translation/review status: Not applicable; no user-facing text changed.

## Security and privacy impact

- [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
- [x] Untrusted text remains safely rendered and bounded.
- [x] Authorization, retention, logging, and external-provider impact were considered where relevant.

The frontend now fails closed when private-mode metadata violates its runtime contract. Backend authorization and provider routing are unchanged.

## Compatibility, migration, and rollback

Omitted `personal_enabled` remains accepted and behaves as disabled. Boolean `true` and `false` remain accepted. Only malformed present values now fail with the existing `invalid_profile` API error. No migration is required; reverting the single commit restores the previous behavior.

## Known limitations

- None within the issue scope.
