### PR TITLE
fix: distinguish private memory actions

### DIFF
--- a/frontend/src/PersonalWorkspace.test.tsx
+++ b/frontend/src/PersonalWorkspace.test.tsx
@@ -68,3 +68,44 @@ it("does not expose the workspace after authentication failure", async () => {
   await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Private workspace token required"));
   expect(screen.queryByRole("button", { name: /Send/ })).not.toBeInTheDocument();
 });
+
+it("identifies duplicate-key memory actions by accessible name and preserves their behavior", async () => {
+  const entries = [
+    { id: "opaque-a", key: "profile.alias", kind: "fact", content: "River Example", status: "pending", source: "manual", updated_at: "2026-01-01" },
+    { id: "opaque-b", key: "profile.alias", kind: "preference", content: "Sky Example", status: "pending", source: "chat", updated_at: "2026-01-02" },
+  ];
+  let resolveConfirm!: (response: Response) => void;
+  const confirmResponse = new Promise<Response>(resolve => { resolveConfirm = resolve; });
+  const fetcher = vi.fn((url: string) => {
+    if (url.endsWith("/entries/opaque-a/confirm")) return confirmResponse;
+    return Promise.resolve(new Response(JSON.stringify(url.endsWith("/entries") ? entries : []), { status: 200 }));
+  });
+  vi.stubGlobal("fetch", fetcher);
+  render(<PersonalWorkspace external={false} />);
+  fireEvent.change(screen.getByLabelText(/Workspace token/), { target: { value: "synthetic-token" } });
+  fireEvent.click(screen.getByRole("button", { name: /Unlock/ }));
+  expect(await screen.findByText("River Example")).toBeInTheDocument();
+
+  const firstConfirm = screen.getByRole("button", { name: "确认 / Confirm: profile.alias, 记忆 1 / memory 1" });
+  const secondConfirm = screen.getByRole("button", { name: "确认 / Confirm: profile.alias, 记忆 2 / memory 2" });
+  const firstEdit = screen.getByRole("button", { name: "编辑 / Edit: profile.alias, 记忆 1 / memory 1" });
+  const secondEdit = screen.getByRole("button", { name: "编辑 / Edit: profile.alias, 记忆 2 / memory 2" });
+  const firstDelete = screen.getByRole("button", { name: "删除 / Delete: profile.alias, 记忆 1 / memory 1" });
+  const secondDelete = screen.getByRole("button", { name: "删除 / Delete: profile.alias, 记忆 2 / memory 2" });
+
+  fireEvent.click(firstConfirm);
+  await waitFor(() => expect(fetcher).toHaveBeenCalledWith(expect.stringContaining("/entries/opaque-a/confirm"), expect.any(Object)));
+  expect(firstConfirm).toBeDisabled();
+  expect(secondConfirm).toBeDisabled();
+  expect(firstEdit).toBeDisabled();
+  expect(secondEdit).toBeDisabled();
+  expect(firstDelete).toBeDisabled();
+  expect(secondDelete).toBeDisabled();
+  resolveConfirm(new Response(JSON.stringify({}), { status: 200 }));
+  await waitFor(() => expect(secondEdit).toBeEnabled());
+
+  fireEvent.click(secondEdit);
+  expect(screen.getByLabelText(/Content/)).toHaveValue("Sky Example");
+  fireEvent.click(secondDelete);
+  await waitFor(() => expect(fetcher).toHaveBeenCalledWith(expect.stringContaining("/entries/opaque-b/delete"), expect.any(Object)));
+});

--- a/frontend/src/PersonalWorkspace.tsx
+++ b/frontend/src/PersonalWorkspace.tsx
@@ -4,6 +4,10 @@ type Entry = { id: string; kind: string; key: string; content: string; status: s
 type Turn = { id: string; role: string; content: string };
 const base = (import.meta.env.VITE_API_BASE_URL ?? "").trim().replace(/\/+$/, "");
 
+function memoryActionName(label: string, entryKey: string, position: number) {
+  return `${label}: ${entryKey}, 记忆 ${position} / memory ${position}`;
+}
+
 export function PersonalWorkspace({ external, maxQuestionChars = 8000 }: { external: boolean; maxQuestionChars?: number }) {
   const questionLimit = Math.min(maxQuestionChars, 8000);
   const [token, setToken] = useState("");
@@ -75,13 +79,13 @@ export function PersonalWorkspace({ external, maxQuestionChars = 8000 }: { exter
         <button disabled={busy}>{editing ? "保存修改为候选 / Save edit as pending" : "添加候选 / Add candidate"}</button>
         {editing && <button type="button" onClick={() => { setEditing(null); setContent(""); }}>取消 / Cancel</button>}
       </form>
-      <ul className="memory-list">{entries.map(entry => <li key={entry.id}>
+      <ul className="memory-list">{entries.map((entry, index) => <li key={entry.id}>
         <strong>{entry.key}</strong> · {entry.kind} · {entry.status === "confirmed" ? "已确认 / Confirmed" : "待确认 / Pending"}
         <p>{entry.content}</p><small>{entry.source} · {entry.updated_at}</small>
         <div className="memory-actions">
-          {entry.status === "pending" && <button disabled={busy} onClick={() => void run(async () => { setConflict(null); await request(`/entries/${entry.id}/confirm`, { replace_ids: [] }); await refresh(); })}>确认 / Confirm</button>}
-          <button disabled={busy} onClick={() => { setEditing(entry.id); setKind(entry.kind); setKey(entry.key); setContent(entry.content); }}>编辑 / Edit</button>
-          <button disabled={busy} onClick={() => void run(async () => { await request(`/entries/${entry.id}/delete`, {}); setConflict(null); await refresh(); })}>删除 / Delete</button>
+          {entry.status === "pending" && <button aria-label={memoryActionName("确认 / Confirm", entry.key, index + 1)} disabled={busy} onClick={() => void run(async () => { setConflict(null); await request(`/entries/${entry.id}/confirm`, { replace_ids: [] }); await refresh(); })}>确认 / Confirm</button>}
+          <button aria-label={memoryActionName("编辑 / Edit", entry.key, index + 1)} disabled={busy} onClick={() => { setEditing(entry.id); setKind(entry.kind); setKey(entry.key); setContent(entry.content); }}>编辑 / Edit</button>
+          <button aria-label={memoryActionName("删除 / Delete", entry.key, index + 1)} disabled={busy} onClick={() => void run(async () => { await request(`/entries/${entry.id}/delete`, {}); setConflict(null); await refresh(); })}>删除 / Delete</button>
         </div>
       </li>)}</ul>
       {conflict && <aside role="alert"><p>确认用新内容替换以下旧记忆？ / Replace these confirmed memories?</p>


### PR DESCRIPTION
## Problem and scope

Private-memory cards repeated the same accessible action names, so screen-reader users could not tell which memory a Confirm, Edit, or Delete button would affect. This change is limited to the private workspace component and its regression tests.

Closes #127

## What changed

- Extend each memory action's accessible name with the memory key and its one-based list position.
- Keep the existing visible bilingual Confirm, Edit, and Delete labels and native button behavior unchanged.
- Add a duplicate-key fixture that selects both memories' actions by role and accessible name.
- Verify confirm, edit, delete, and busy-state behavior without using array-position queries or database IDs as accessible context.

## Verification evidence

- [x] `make lint`
- [x] `make test`
- [x] `make docs`
- [x] `make evaluate`
- [ ] `make build`

Relevant output, screenshots, or evaluation case counts:

- `make lint`: passed, including lock, version, Ruff, ESLint, and TypeScript checks.
- `make test`: 230 backend tests and 147 frontend tests passed.
- `make knowledge-check`: 1 knowledge document passed validation.
- `make docs`: 52 Markdown files and 16 maintained lesson pages passed validation.
- `make evaluate`: 4/4 collaboration cases passed.
- `npm run build`: passed; Vite production bundle built successfully.
- `make build`: attempted, but Docker Desktop is not running (`Cannot connect to the Docker daemon`).
- No screenshot is included because the visible UI is unchanged.

## Course and translation impact

- [x] No course behavior or explanation changed.
- [ ] English course/docs were updated.
- [ ] Maintained translations were updated or a follow-up issue is linked.
- [ ] New commands and links were run/checked.

Translation/review status: Existing bilingual visible labels are unchanged. The new accessible context is bilingual; broader private-workspace localization remains out of scope under #112.

## Security and privacy impact

- [x] No secrets, `.env` contents, private documents, production prompts, database files, or personal records are included.
- [x] Untrusted text remains safely rendered and bounded.
- [x] Authorization, retention, logging, and external-provider impact were considered where relevant.

Describe impact or write `none`: No security or privacy behavior changes. Accessible names use the already rendered memory key plus list position and do not expose entry IDs or memory content.

## Compatibility, migration, and rollback

No API, schema, storage, or migration changes. Roll back the single component/test commit to restore the previous accessible names.

## Known limitations

- List positions reflect the current rendered order and may change when entries are refreshed or reordered.
